### PR TITLE
Client testing

### DIFF
--- a/.lamingtonrc
+++ b/.lamingtonrc
@@ -1,6 +1,6 @@
 {
   "cdt": "https://github.com/EOSIO/eosio.cdt/releases/download/v1.8.1/eosio.cdt_1.8.1-1-ubuntu-18.04_amd64.deb",
-  "eos": "https://github.com/EOSIO/eos/releases/download/v2.1.0/eosio_2.1.0-1-ubuntu-18.04_amd64.deb",
+  "eos": "https://github.com/EOSIO/eos/releases/download/v2.0.13/eosio_2.0.13-1-ubuntu-18.04_amd64.deb",
   "contracts": "v1.9.2",
   "debug": 0,
   "debugTransactions": false,

--- a/contracts/TestHelpers.ts
+++ b/contracts/TestHelpers.ts
@@ -129,7 +129,7 @@ export class SharedTestObjects {
     this.msigworlds_contract = await debugPromise(
       ContractDeployer.deployWithName<Msigworlds>(
         'contracts/msigworlds/msigworlds',
-        'msigworlds'
+        'msig.world'
       ),
       'created msigworlds_contract'
     );
@@ -143,7 +143,7 @@ export class SharedTestObjects {
     );
 
     // Other objects
-    this.configured_dac_memberterms = 'AgreedMemberTermsHashValue';
+    this.configured_dac_memberterms = 'be2c9d0494417cf7522cd8d6f774477c';
     await this.add_token_contract_permissions();
     await this.configTokenContract();
   }
@@ -734,7 +734,7 @@ export class SharedTestObjects {
   async setup_dac_memberterms(dacId: string, dacAuth: Account) {
     await debugPromise(
       this.dac_token_contract.newmemterms(
-        'teermsstring',
+        'https://raw.githubusercontent.com/eosdac/eosdac-constitution/master/constitution.md',
         this.configured_dac_memberterms,
         dacId,
         { from: dacAuth }

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -17,10 +17,9 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { DaccustodianCandidate } from './daccustodian';
 chai.use(chaiAsPromised);
+let shared: SharedTestObjects;
 
 describe('Daccustodian', () => {
-  let shared: SharedTestObjects;
-
   before(async () => {
     shared = await chai.expect(SharedTestObjects.getInstance()).to.be.fulfilled;
   });
@@ -1048,8 +1047,9 @@ describe('Daccustodian', () => {
             }
           );
           context('with enough candidates to fill the configs', async () => {
+            let candidates: Account[];
             before(async () => {
-              let candidates = await shared.getStakeObservedCandidates(
+              candidates = await shared.getStakeObservedCandidates(
                 dacId,
                 '12.0000 PERDAC'
               );
@@ -1199,6 +1199,9 @@ describe('Daccustodian', () => {
               chai.expect(oneAccounts[0].weight).to.eq(1);
             });
           });
+          // it('should succeed setting up testuser', async () => {
+          //   await setup_test_user(candidates[0], 'PERDAC');
+          // });
         });
       });
     });
@@ -2006,3 +2009,15 @@ describe('Daccustodian', () => {
     });
   });
 });
+
+async function setup_test_user(testuser: Account, tokenSymbol: string) {
+  // const testuser = await AccountManager.createAccount('clienttest');
+  console.log(`testuser: ${JSON.stringify(testuser, null, 2)}`);
+  await shared.dac_token_contract.transfer(
+    shared.dac_token_contract.account.name,
+    testuser.name,
+    `1200.0000 ${tokenSymbol}`,
+    '',
+    { from: shared.dac_token_contract.account }
+  );
+}

--- a/contracts/dacproposals/dacproposals.test.ts
+++ b/contracts/dacproposals/dacproposals.test.ts
@@ -19,6 +19,7 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);
+let shared: SharedTestObjects;
 
 enum VoteType {
   vote_abstain = 0,
@@ -38,7 +39,6 @@ enum ProposalState {
 let proposalHash = 'jhsdfkjhsdfkjhkjsdf';
 
 describe('Dacproposals', () => {
-  let shared: SharedTestObjects;
   let otherAccount: Account;
   let proposer1Account: Account;
   let arbitrator: Account;
@@ -2696,6 +2696,21 @@ describe('Dacproposals', () => {
           2
         );
       });
+      it('should succeed setting up testuser', async () => {
+        await setup_test_user(propDacCustodians[0], 'PROPDAC');
+      });
     });
   });
 });
+
+async function setup_test_user(testuser: Account, tokenSymbol: string) {
+  // const testuser = await AccountManager.createAccount('clienttest');
+  console.log(`testuser: ${JSON.stringify(testuser, null, 2)}`);
+  await shared.dac_token_contract.transfer(
+    shared.dac_token_contract.account.name,
+    testuser.name,
+    `1200.0000 ${tokenSymbol}`,
+    '',
+    { from: shared.dac_token_contract.account }
+  );
+}

--- a/contracts/referendum/referendum.hpp
+++ b/contracts/referendum/referendum.hpp
@@ -14,7 +14,7 @@
 #include "../../contract-shared-headers/dacdirectory_shared.hpp"
 #include "../../contract-shared-headers/eosdactokens_shared.hpp"
 
-#define SYSTEM_MSIG_CONTRACT "msigworlds"
+#define SYSTEM_MSIG_CONTRACT "msig.world"
 // WARNING : Do not use ENABLE_BINDING_VOTE if this will be a shared contract (ie RESTRICT_DAC should be set if
 // ENABLE_BINDING_VOTE==1)
 //#ifndef ENABLE_BINDING_VOTE


### PR DESCRIPTION
This switches the nodeos version back to 2.0 as eosio-statereceiver which is used in the eosdac-api hasn't been updated to work with 2.1. It also makes a few small additions for covenient client testing.