### PR TITLE
Setbudget

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortLambdasOnASingleLine: Empty

--- a/contract-shared-headers/common_utilities.hpp
+++ b/contract-shared-headers/common_utilities.hpp
@@ -96,8 +96,8 @@ inline void check(bool pred, const std::string_view format, Args const &...args)
  * @return true - if a new table entry was created
  * @return false - if an existing table entry was updated
  */
-template <typename Table, typename Pk, typename Function>
-inline bool upsert(Table &table, const Pk &pk, const eosio::name payer, const Function &updater) {
+template <typename Table, typename Function>
+inline bool upsert(Table &table, const uint64_t pk, const eosio::name payer, const Function &updater) {
     const auto itr = table.find(pk);
     if (itr == table.end()) {
         table.emplace(payer, updater);

--- a/contracts/TestHelpers.ts
+++ b/contracts/TestHelpers.ts
@@ -174,7 +174,7 @@ export class SharedTestObjects {
     initialAsset: string,
     planet: ?Account
   ) {
-    this.setup_new_auth_account();
+    await this.setup_new_auth_account();
     // Further setup after the inital singleton object have been created.
     await this.setup_tokens(initialAsset);
     await this.register_dac_with_directory(dacId, symbol, planet);

--- a/contracts/daccustodian/daccustodian.hpp
+++ b/contracts/daccustodian/daccustodian.hpp
@@ -12,6 +12,32 @@
 
 using namespace std;
 
+#define PROPERTY(type, name)                                                                                           \
+    type get_##name() const {                                                                                          \
+        return get<type>(state_keys::name);                                                                            \
+    }                                                                                                                  \
+    void set_##name(const type value) {                                                                                \
+        set(state_keys::name, value);                                                                                  \
+    }
+
+#define PROPERTY_OPTIONAL_TYPECASTING(type, storage_type, name)                                                        \
+    std::optional<type> get_##name() const {                                                                           \
+        const auto p = get_maybe<storage_type>(state_keys::name);                                                      \
+        if (p) {                                                                                                       \
+            return type(*p);                                                                                           \
+        } else {                                                                                                       \
+            return {};                                                                                                 \
+        }                                                                                                              \
+    }                                                                                                                  \
+    void set_##name(const type value) {                                                                                \
+        set(state_keys::name, storage_type(value));                                                                    \
+    }                                                                                                                  \
+    void unset_##name() {                                                                                              \
+        const auto search = data.find(state_keys::name);                                                               \
+        check(search != data.end(), "Cannot unset " #name ", no value set");                                           \
+        data.erase(state_keys::budget_percentage);                                                                     \
+    }
+
 namespace eosdac {
 
     static constexpr eosio::name ONE_PERMISSION    = "one"_n;
@@ -158,63 +184,12 @@ namespace eosdac {
          * What follows are type-safe getters/setters for polymorphic map values
          **/
 
-        // budget_percentage
-        void set_budget_percentage(const uint16_t percentage) {
-            set(state_keys::budget_percentage, uint32_t(percentage));
-        }
-        void unset_budget_percentage() {
-            const auto search = data.find(state_keys::budget_percentage);
-            check(search != data.end(), "Cannot unset budget_percentage, no value set");
-            data.erase(state_keys::budget_percentage);
-        }
-        std::optional<uint16_t> get_budget_percentage() const {
-            const auto p = get_maybe<uint32_t>(state_keys::budget_percentage);
-            if (p) {
-                return uint16_t(*p);
-            } else {
-                return {};
-            }
-        }
-
-        // lastclaimbudgettime
-        time_point_sec get_lastclaimbudgettime() const {
-            return get<time_point_sec>(state_keys::lastclaimbudgettime);
-        }
-        void set_lastclaimbudgettime(time_point_sec value) {
-            set(state_keys::lastclaimbudgettime, value);
-        }
-
-        // total_weight_of_votes
-        int64_t get_total_weight_of_votes() const {
-            return get<int64_t>(state_keys::total_weight_of_votes);
-        }
-        void set_total_weight_of_votes(const int64_t value) {
-            set(state_keys::total_weight_of_votes, value);
-        }
-
-        // met_initial_votes_threshold
-        bool get_met_initial_votes_threshold() const {
-            return get<bool>(state_keys::met_initial_votes_threshold);
-        }
-        void set_met_initial_votes_threshold(const bool value) {
-            set(state_keys::met_initial_votes_threshold, value);
-        }
-
-        // number_active_candidates
-        uint32_t get_number_active_candidates() const {
-            return get<uint32_t>(state_keys::number_active_candidates);
-        }
-        void set_number_active_candidates(const uint32_t value) {
-            set(state_keys::number_active_candidates, value);
-        }
-
-        // total_votes_on_candidates
-        int64_t get_total_votes_on_candidates() const {
-            return get<int64_t>(state_keys::total_votes_on_candidates);
-        }
-        void set_total_votes_on_candidates(const int64_t value) {
-            set(state_keys::total_votes_on_candidates, value);
-        }
+        PROPERTY_OPTIONAL_TYPECASTING(uint16_t, uint32_t, budget_percentage);
+        PROPERTY(time_point_sec, lastclaimbudgettime);
+        PROPERTY(int64_t, total_weight_of_votes);
+        PROPERTY(bool, met_initial_votes_threshold);
+        PROPERTY(uint32_t, number_active_candidates);
+        PROPERTY(int64_t, total_votes_on_candidates);
     };
 
     struct [[eosio::table("votes"), eosio::contract("daccustodian")]] vote {

--- a/contracts/daccustodian/daccustodian.hpp
+++ b/contracts/daccustodian/daccustodian.hpp
@@ -209,10 +209,10 @@ namespace eosdac {
         }
 
         // total_votes_on_candidates
-        int64_t get_total_votes_on_candidates() {
+        int64_t get_total_votes_on_candidates() const {
             return get<int64_t>(state_keys::total_votes_on_candidates);
         }
-        void set_total_votes_on_candidates(int64_t value) {
+        void set_total_votes_on_candidates(const int64_t value) {
             set(state_keys::total_votes_on_candidates, value);
         }
     };

--- a/contracts/daccustodian/daccustodian.hpp
+++ b/contracts/daccustodian/daccustodian.hpp
@@ -259,6 +259,7 @@ namespace eosdac {
         ACTION claimbudget(const name &dac_id);
         ACTION migratestate(const name &dac_id);
         ACTION setbudget(const name &dac_id, const uint16_t percentage);
+        ACTION unsetbudget(const name &dac_id);
 #ifdef DEBUG
         ACTION resetvotes(const name &voter, const name &dac_id);
         ACTION resetcands(const name &dac_id);
@@ -314,5 +315,6 @@ namespace eosdac {
         void             validateUnstake(name code, name cand, name dac_id);
         void validateUnstakeAmount(const name &code, const name &cand, const asset &unstake_amount, const name &dac_id);
         void validateMinStake(name account, name dac_id);
+        uint16_t get_budget_percentage(const name &dac_id);
     };
 }; // namespace eosdac

--- a/contracts/daccustodian/daccustodian.hpp
+++ b/contracts/daccustodian/daccustodian.hpp
@@ -154,7 +154,11 @@ namespace eosdac {
             }
         }
 
-        // getters/setters
+        /**
+         * What follows are type-safe getters/setters for polymorphic map values
+         **/
+
+        // budget_percentage
         void set_budget_percentage(const uint16_t percentage) {
             set(state_keys::budget_percentage, uint32_t(percentage));
         }
@@ -172,9 +176,45 @@ namespace eosdac {
             }
         }
 
-        // time_point_sec get_lastclaimbudgettime() {
-        //     return state.get<time_point_sec>(state_keys::lastclaimbudgettime);
-        // }
+        // lastclaimbudgettime
+        time_point_sec get_lastclaimbudgettime() const {
+            return get<time_point_sec>(state_keys::lastclaimbudgettime);
+        }
+        void set_lastclaimbudgettime(time_point_sec value) {
+            set(state_keys::lastclaimbudgettime, value);
+        }
+
+        // total_weight_of_votes
+        int64_t get_total_weight_of_votes() const {
+            return get<int64_t>(state_keys::total_weight_of_votes);
+        }
+        void set_total_weight_of_votes(const int64_t value) {
+            set(state_keys::total_weight_of_votes, value);
+        }
+
+        // met_initial_votes_threshold
+        bool get_met_initial_votes_threshold() const {
+            return get<bool>(state_keys::met_initial_votes_threshold);
+        }
+        void set_met_initial_votes_threshold(const bool value) {
+            set(state_keys::met_initial_votes_threshold, value);
+        }
+
+        // number_active_candidates
+        uint32_t get_number_active_candidates() const {
+            return get<uint32_t>(state_keys::number_active_candidates);
+        }
+        void set_number_active_candidates(const uint32_t value) {
+            set(state_keys::number_active_candidates, value);
+        }
+
+        // total_votes_on_candidates
+        int64_t get_total_votes_on_candidates() {
+            return get<int64_t>(state_keys::total_votes_on_candidates);
+        }
+        void set_total_votes_on_candidates(int64_t value) {
+            set(state_keys::total_votes_on_candidates, value);
+        }
     };
 
     struct [[eosio::table("votes"), eosio::contract("daccustodian")]] vote {

--- a/contracts/daccustodian/daccustodian.hpp
+++ b/contracts/daccustodian/daccustodian.hpp
@@ -101,11 +101,11 @@ namespace eosdac {
     struct [[eosio::table("state2"), eosio::contract("daccustodian")]] contr_state2 {
         eosio::time_point_sec                  lastperiodtime = time_point_sec(0);
         std::map<uint8_t, state_value_variant> data           = {
-                      {state_keys::total_weight_of_votes, int64_t(0)},
-                      {state_keys::total_votes_on_candidates, int64_t(0)},
-                      {state_keys::number_active_candidates, uint32_t(0)},
-                      {state_keys::met_initial_votes_threshold, false},
-                      {state_keys::lastclaimbudgettime, time_point_sec(0)},
+            {state_keys::total_weight_of_votes, int64_t(0)},
+            {state_keys::total_votes_on_candidates, int64_t(0)},
+            {state_keys::number_active_candidates, uint32_t(0)},
+            {state_keys::met_initial_votes_threshold, false},
+            {state_keys::lastclaimbudgettime, time_point_sec(0)},
         };
 
         static contr_state2 get_migrated_state(const eosio::name account, const eosio::name dac_id) {
@@ -209,6 +209,16 @@ namespace eosdac {
 
     using candperms_table = multi_index<"candperms"_n, candperm>;
 
+    struct [[eosio::table("budget"), eosio::contract("daccustodian")]] budget_settings_item {
+        name     dac_id;
+        uint16_t percentage;
+
+        uint64_t primary_key() const {
+            return dac_id.value;
+        }
+    };
+    using budget_settings_table = multi_index<"budget"_n, budget_settings_item>;
+
     class daccustodian : public contract {
 
       public:
@@ -248,6 +258,7 @@ namespace eosdac {
         ACTION paycpu(const name &dac_id);
         ACTION claimbudget(const name &dac_id);
         ACTION migratestate(const name &dac_id);
+        ACTION setbudget(const name &dac_id, const uint16_t percentage);
 #ifdef DEBUG
         ACTION resetvotes(const name &voter, const name &dac_id);
         ACTION resetcands(const name &dac_id);

--- a/contracts/daccustodian/daccustodian.hpp
+++ b/contracts/daccustodian/daccustodian.hpp
@@ -42,7 +42,7 @@ using namespace std;
     void unset_##name() {                                                                                              \
         const auto search = data.find(state_keys::name);                                                               \
         check(search != data.end(), "Cannot unset " #name ", no value set");                                           \
-        data.erase(state_keys::budget_percentage);                                                                     \
+        data.erase(state_keys::name);                                                                                  \
     }
 
 namespace eosdac {

--- a/contracts/daccustodian/daccustodian.hpp
+++ b/contracts/daccustodian/daccustodian.hpp
@@ -12,6 +12,9 @@
 
 using namespace std;
 
+/**
+ * simple getter/setter
+ **/
 #define PROPERTY(type, name)                                                                                           \
     type get_##name() const {                                                                                          \
         return get<type>(state_keys::name);                                                                            \
@@ -20,6 +23,15 @@ using namespace std;
         set(state_keys::name, value);                                                                                  \
     }
 
+/**
+ * A slightly more complicated getter/setter macro that allows optional values.
+ * If value is not set, it returns a null optional. To unset a previously set
+ * value, it has an unset function.
+ * Since our variant can only hold certain number types, we sometimes need to
+ * convert our desired type to a storage_type. Before storing, it will convert
+ * the value to the storage_type and before returning, the getter will
+ * automatically convert back to type.
+ **/
 #define PROPERTY_OPTIONAL_TYPECASTING(type, storage_type, name)                                                        \
     std::optional<type> get_##name() const {                                                                           \
         const auto p = get_maybe<storage_type>(state_keys::name);                                                      \

--- a/contracts/daccustodian/daccustodian.hpp
+++ b/contracts/daccustodian/daccustodian.hpp
@@ -34,12 +34,7 @@ using namespace std;
  **/
 #define PROPERTY_OPTIONAL_TYPECASTING(type, storage_type, name)                                                        \
     std::optional<type> get_##name() const {                                                                           \
-        const auto p = get_maybe<storage_type>(state_keys::name);                                                      \
-        if (p) {                                                                                                       \
-            return type(*p);                                                                                           \
-        } else {                                                                                                       \
-            return {};                                                                                                 \
-        }                                                                                                              \
+        return get_maybe<storage_type>(state_keys::name);                                                              \
     }                                                                                                                  \
     void set_##name(const type value) {                                                                                \
         set(state_keys::name, storage_type(value));                                                                    \

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -15,7 +15,6 @@ import {
 
 import { SharedTestObjects, NUMBER_OF_CANDIDATES } from '../TestHelpers';
 import * as chai from 'chai';
-const { Serialize } = require('eosjs');
 import * as chaiAsPromised from 'chai-as-promised';
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
@@ -24,7 +23,6 @@ import { DaccustodianCandidate } from './daccustodian';
 chai.use(chaiAsPromised);
 let shared: SharedTestObjects;
 const now = dayjs.utc();
-const Int64LE = require('int64-buffer').Int64LE;
 
 const NFT_COLLECTION = 'alien.worlds';
 const BUDGET_SCHEMA = 'budget';
@@ -2700,21 +2698,4 @@ async function get_balance(
     }
   }
   return 0.0;
-}
-
-function template_and_value_key_ascending(schema_name, value) {
-  return (BigInt(nameToInt(schema_name)) << BigInt(64)) | BigInt(value);
-}
-
-function nameToInt(name) {
-  const sb = new Serialize.SerialBuffer({
-    textEncoder: new TextEncoder(),
-    textDecoder: new TextDecoder(),
-  });
-
-  sb.pushName(name);
-
-  const name_64 = new Int64LE(sb.array);
-
-  return name_64 + '';
 }

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -31,9 +31,10 @@ const BUDGET_SCHEMA = 'budget';
 
 describe('Daccustodian', () => {
   let second_nft_id: Number;
-
+  let somebody: Account;
   before(async () => {
     shared = await SharedTestObjects.getInstance();
+    somebody = await await AccountManager.createAccount();
   });
   context('fillstate', async () => {
     let dacId = 'migratedac';
@@ -510,14 +511,12 @@ describe('Daccustodian', () => {
             );
           });
           it('should succeed', async () => {
-            await chai.expect(
-              shared.daccustodian_contract.nominatecane(
-                newUser1.name,
-                '25.0000 EOS',
-                dacId,
-                { from: newUser1 }
-              )
-            ).eventually.be.fulfilled;
+            await shared.daccustodian_contract.nominatecane(
+              newUser1.name,
+              '25.0000 EOS',
+              dacId,
+              { from: newUser1 }
+            );
           });
         });
       });
@@ -558,14 +557,12 @@ describe('Daccustodian', () => {
           );
         });
         it('should succeed', async () => {
-          await chai.expect(
-            shared.daccustodian_contract.nominatecane(
-              newUser1.name,
-              '25.0000 EOS',
-              dacId,
-              { from: newUser1 }
-            )
-          ).eventually.be.fulfilled;
+          await shared.daccustodian_contract.nominatecane(
+            newUser1.name,
+            '25.0000 EOS',
+            dacId,
+            { from: newUser1 }
+          );
         });
         it('should fail to unstake', async () => {
           await assertEOSErrorIncludesMessage(
@@ -873,11 +870,13 @@ describe('Daccustodian', () => {
       });
       context('with correct auth', async () => {
         it('should succeed', async () => {
-          await chai.expect(
-            shared.daccustodian_contract.regproxy(regMembers[0].name, dacId, {
+          await shared.daccustodian_contract.regproxy(
+            regMembers[0].name,
+            dacId,
+            {
               from: regMembers[0],
-            })
-          ).to.eventually.be.fulfilled;
+            }
+          );
         });
       });
     });
@@ -1008,13 +1007,11 @@ describe('Daccustodian', () => {
         });
         context('with correct auth', async () => {
           it('should succeed', async () => {
-            await chai.expect(
-              shared.daccustodian_contract.unregproxy(
-                regMembers[0].name,
-                dacId,
-                { from: regMembers[0] }
-              )
-            ).to.eventually.be.fulfilled;
+            await shared.daccustodian_contract.unregproxy(
+              regMembers[0].name,
+              dacId,
+              { from: regMembers[0] }
+            );
           });
         });
       });
@@ -1152,32 +1149,30 @@ describe('Daccustodian', () => {
 
               // Change the config to a lower requestedPayMax to affect average pay tests after `newperiod` succeeds.
               // This change to `23.0000 EOS` should cause the requested pays of 25.0000 EOS to be fitered from the mean pay.
-              await chai.expect(
-                shared.daccustodian_contract.updateconfige(
-                  {
-                    numelected: 5,
-                    maxvotes: 4,
-                    requested_pay_max: {
-                      contract: 'eosio.token',
-                      quantity: '23.0000 EOS',
-                    },
-                    periodlength: 5,
-                    initial_vote_quorum_percent: 31,
-                    vote_quorum_percent: 15,
-                    auth_threshold_high: 4,
-                    auth_threshold_mid: 3,
-                    auth_threshold_low: 2,
-                    lockupasset: {
-                      contract: shared.dac_token_contract.account.name,
-                      quantity: '12.0000 PERDAC',
-                    },
-                    should_pay_via_service_provider: false,
-                    lockup_release_time_delay: 1233,
+              await shared.daccustodian_contract.updateconfige(
+                {
+                  numelected: 5,
+                  maxvotes: 4,
+                  requested_pay_max: {
+                    contract: 'eosio.token',
+                    quantity: '23.0000 EOS',
                   },
-                  dacId,
-                  { from: shared.auth_account }
-                )
-              ).to.eventually.be.fulfilled;
+                  periodlength: 5,
+                  initial_vote_quorum_percent: 31,
+                  vote_quorum_percent: 15,
+                  auth_threshold_high: 4,
+                  auth_threshold_mid: 3,
+                  auth_threshold_low: 2,
+                  lockupasset: {
+                    contract: shared.dac_token_contract.account.name,
+                    quantity: '12.0000 PERDAC',
+                  },
+                  should_pay_via_service_provider: false,
+                  lockup_release_time_delay: 1233,
+                },
+                dacId,
+                { from: shared.auth_account }
+              );
             });
             it('should succeed with custodians populated', async () => {
               await shared.daccustodian_contract.newperiod(
@@ -1333,15 +1328,13 @@ describe('Daccustodian', () => {
           await sleep(4_000);
         });
         it('should succeed', async () => {
-          await chai.expect(
-            shared.daccustodian_contract.newperiod(
-              'initial new period',
-              dacId,
-              {
-                from: newUser1,
-              }
-            )
-          ).to.eventually.be.fulfilled;
+          await shared.daccustodian_contract.newperiod(
+            'initial new period',
+            dacId,
+            {
+              from: newUser1,
+            }
+          );
         });
         it('custodians should have been paid', async () => {
           await assertRowCount(
@@ -1743,13 +1736,11 @@ describe('Daccustodian', () => {
             .to.be.equal(numberActiveCandidatesBefore - 1);
         });
         it('should allow unstaking without a timelock error', async () => {
-          await chai.expect(
-            shared.dac_token_contract.unstake(
-              unelectedCandidateToResign.name,
-              '12.0000 WITHDAC',
-              { from: unelectedCandidateToResign }
-            )
-          ).to.eventually.be.fulfilled;
+          await shared.dac_token_contract.unstake(
+            unelectedCandidateToResign.name,
+            '12.0000 WITHDAC',
+            { from: unelectedCandidateToResign }
+          );
         });
       });
     });
@@ -2066,15 +2057,13 @@ describe('Daccustodian', () => {
       );
     });
     it('should succeed with correct auth', async () => {
-      await chai.expect(
-        shared.daccustodian_contract.appointcust(
-          accountsToRegister.map((account) => {
-            return account.name;
-          }),
-          dacId,
-          { from: shared.auth_account }
-        )
-      ).to.eventually.be.fulfilled;
+      await shared.daccustodian_contract.appointcust(
+        accountsToRegister.map((account) => {
+          return account.name;
+        }),
+        dacId,
+        { from: shared.auth_account }
+      );
       let candidates = await shared.daccustodian_contract.candidatesTable({
         scope: dacId,
         limit: 20,
@@ -2322,7 +2311,8 @@ describe('Daccustodian', () => {
             'TLM'
           );
           expected_transfer_amount = await expected_budget_transfer_amount(
-            dacId
+            dacId,
+            false
           );
           await shared.daccustodian_contract.claimbudget(dacId);
         });
@@ -2352,6 +2342,11 @@ describe('Daccustodian', () => {
       }
     );
     context('setbudget', async () => {
+      it('without self auth, should throw authentication error', async () => {
+        await assertMissingAuthority(
+          shared.daccustodian_contract.setbudget(dacId, 123, { from: somebody })
+        );
+      });
       it('should work', async () => {
         console.log('dacId: ', dacId);
         await shared.daccustodian_contract.setbudget(dacId, 123);
@@ -2360,7 +2355,7 @@ describe('Daccustodian', () => {
         const res = await shared.daccustodian_contract.budgetTable({
           lowerBound: dacId,
           upperBound: dacId,
-          keyType: 'i64',
+          keyType: 'name',
         });
         chai.expect(res.rows[0].dac_id).to.equal(dacId);
         chai.expect(res.rows[0].percentage).to.equal(123);
@@ -2369,7 +2364,7 @@ describe('Daccustodian', () => {
         console.log('dacId: ', dacId);
         await shared.daccustodian_contract.setbudget(dacId, 234);
       });
-      it('should update table entry', async () => {
+      it('should update existing table entry', async () => {
         const res = await shared.daccustodian_contract.budgetTable({
           lowerBound: dacId,
           upperBound: dacId,
@@ -2401,7 +2396,14 @@ describe('Daccustodian', () => {
       });
     });
     context('unsetbudget', async () => {
-      it('with non-existing dac id', async () => {
+      it('without self auth, should throw authentication error', async () => {
+        await assertMissingAuthority(
+          shared.daccustodian_contract.unsetbudget(dacId, {
+            from: somebody,
+          })
+        );
+      });
+      it('with non-existing dac id, should throw not exists error', async () => {
         // console.log('dacId: ', dacId);
         await assertEOSErrorIncludesMessage(
           shared.daccustodian_contract.unsetbudget('notexist'),
@@ -2454,7 +2456,10 @@ describe('Daccustodian', () => {
           shared.auth_account,
           'TLM'
         );
-        expected_transfer_amount = await expected_budget_transfer_amount(dacId);
+        expected_transfer_amount = await expected_budget_transfer_amount(
+          dacId,
+          true
+        );
         await shared.daccustodian_contract.claimbudget(dacId);
       });
       it('should transfer amount according to formula', async () => {
@@ -2634,7 +2639,10 @@ async function setup_test_user(testuser: Account, tokenSymbol: string) {
   );
 }
 
-async function expected_budget_transfer_amount(dacId: string) {
+async function expected_budget_transfer_amount(
+  dacId: string,
+  assert_manual: bool
+) {
   const auth_balance = await get_balance(
     shared.eosio_token_contract,
     shared.auth_account,
@@ -2653,10 +2661,12 @@ async function expected_budget_transfer_amount(dacId: string) {
   });
   let percentage;
   if (res.rows.length) {
+    chai.expect(assert_manual).to.be.true;
     // we have manually set budget percentage
     chai.expect(res.rows.length).to.equal(1);
     percentage = res.rows[0].percentage;
   } else {
+    chai.expect(assert_manual).to.be.false;
     const nft_res = await shared.dacdirectory_contract.nftcacheTable({
       scope: dacId,
     });

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -338,7 +338,7 @@ uint16_t daccustodian::get_budget_percentage(const name &dac_id) {
         const auto index    = nftcache.get_index<"valdesc"_n>();
 
         const auto index_key = dacdir::nftcache::template_and_value_key_ascending(BUDGET_SCHEMA, 0);
-        auto       itr       = index.lower_bound(index_key);
+        const auto itr       = index.lower_bound(index_key);
         check(itr != index.end() && itr->schema_name == BUDGET_SCHEMA, "Dac with ID %s does not own any budget NFTs",
             dac_id);
 

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -196,6 +196,16 @@ asset balance_for_type(const dacdir::dac &dac, const dacdir::account_type type) 
     return eosdac::get_balance_graceful(account, TLM_TOKEN_CONTRACT, TLM_SYM);
 }
 
+ACTION daccustodian::setbudget(const name &dac_id, const uint16_t percentage) {
+    require_auth(get_self());
+
+    auto budget_settings = budget_settings_table{get_self(), get_self().value};
+    upsert(budget_settings, dac_id.value, get_self(), [&](auto &b) {
+        b.dac_id     = dac_id;
+        b.percentage = percentage;
+    });
+}
+
 ACTION daccustodian::claimbudget(const name &dac_id) {
     auto state = contr_state2::get_current_state(get_self(), dac_id);
     check(state.get<time_point_sec>(state_keys::lastclaimbudgettime) < state.lastperiodtime,

--- a/contracts/daccustodian/privatehelpers.cpp
+++ b/contracts/daccustodian/privatehelpers.cpp
@@ -36,8 +36,8 @@ void daccustodian::updateVoteWeights(const vector<name> &votes, int64_t vote_wei
 
     if (vote_delta != 0) {
         auto       currentState              = contr_state2::get_current_state(get_self(), dac_id);
-        const auto total_votes_on_candidates = currentState.get<int64_t>(state_keys::total_votes_on_candidates);
-        currentState.set(state_keys::total_votes_on_candidates, total_votes_on_candidates + vote_delta);
+        const auto total_votes_on_candidates = currentState.get_total_votes_on_candidates();
+        currentState.set_total_votes_on_candidates(total_votes_on_candidates + vote_delta);
         currentState.save(get_self(), dac_id);
     }
 }
@@ -77,7 +77,7 @@ void daccustodian::modifyVoteWeights(int64_t vote_weight, vector<name> oldVotes,
     auto currentState = contr_state2::get_current_state(get_self(), dac_id);
 
     // New voter -> Add the tokens to the total weight.
-    auto total_weight_of_votes = currentState.get<int64_t>(state_keys::total_weight_of_votes);
+    auto total_weight_of_votes = currentState.get_total_weight_of_votes();
     if (vote_weight > 0) {
         check((total_weight_of_votes + vote_weight) >= total_weight_of_votes, "Overflow in total_weight_of_votes");
     } else {
@@ -91,7 +91,7 @@ void daccustodian::modifyVoteWeights(int64_t vote_weight, vector<name> oldVotes,
     if (newVotes.size() == 0)
         total_weight_of_votes -= vote_weight;
 
-    currentState.set(state_keys::total_weight_of_votes, total_weight_of_votes);
+    currentState.set_total_weight_of_votes(total_weight_of_votes);
     currentState.save(get_self(), dac_id);
 
     updateVoteWeights(oldVotes, -vote_weight, dac_id);

--- a/contracts/daccustodian/registering.cpp
+++ b/contracts/daccustodian/registering.cpp
@@ -16,8 +16,8 @@ ACTION daccustodian::nominatecane(const name &cand, const asset &requestedpay, c
 
     validateMinStake(cand, dac_id);
 
-    const auto number_active_candidates = currentState.get<uint32_t>(state_keys::number_active_candidates);
-    currentState.set(state_keys::number_active_candidates, number_active_candidates + 1);
+    const auto number_active_candidates = currentState.get_number_active_candidates();
+    currentState.set_number_active_candidates(number_active_candidates + 1);
     currentState.save(get_self(), dac_id);
 
     candidates_table registered_candidates(get_self(), dac_id.value);
@@ -171,8 +171,8 @@ void daccustodian::removeCandidate(name cand, bool lockupStake, name dac_id) {
     auto         currentState = contr_state2::get_current_state(_self, dac_id);
     contr_config configs      = contr_config::get_current_configs(_self, dac_id);
 
-    const auto number_active_candidates = currentState.get<uint32_t>(state_keys::number_active_candidates);
-    currentState.set(state_keys::number_active_candidates, number_active_candidates - 1);
+    const auto number_active_candidates = currentState.get_number_active_candidates();
+    currentState.set_number_active_candidates(number_active_candidates - 1);
     currentState.save(_self, dac_id);
 
     candidates_table registered_candidates(_self, dac_id.value);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@typescript-eslint/parser": "^5.11.0",
     "dayjs": "^1.11.1",
     "eslint": "^8.8.0",
-    "int64-buffer": "^1.0.1",
     "typescript-logging": "^0.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/parser": "^5.11.0",
     "dayjs": "^1.11.1",
     "eslint": "^8.8.0",
+    "int64-buffer": "^1.0.1",
     "typescript-logging": "^0.6.3"
   }
 }


### PR DESCRIPTION
This PR implements the ticket "Add ability to set the Treasury budget amount directly".

Two new ACTIONSs: setbudget and unsetbudget. When budget is set using setbudget, claimbudget will use the percentage defined there. If not, it checks if a budget NFT is held by the DAC and uses the percentage there, raising error, otherwise.

It also imroves on the tests a little bit:

1) Dynamic calculation of expected budget transfer amount in Javascript and comparison with actual budget transfer calculated by the contract. Works both when budget is manually set by the administrator using the setbudget action as well as when it's not and a budget NFT is present.
2) Eosjs 22 compatibility (when run with new version of lamington that uses eosjs 22)

