### PR TITLE
safemath-improvements + related contract changes

### DIFF
--- a/contract-shared-headers/common_utilities.hpp
+++ b/contract-shared-headers/common_utilities.hpp
@@ -79,7 +79,7 @@ inline char *fmt(const std::string_view format, Args const &...args) {
  * helpful error messages.
  */
 template <typename... Args>
-inline void check(bool pred, const std::string_view format, Args const &...args) {
+constexpr void check(const bool pred, const std::string_view format, Args const &...args) {
     if (!pred) {
         const auto msg = fmt(format, args...);
         check(pred, msg);
@@ -113,13 +113,4 @@ inline bool upsert(Table &table, const uint64_t pk, const eosio::name payer, con
 
 inline time_point_sec now() {
     return time_point_sec(current_time_point());
-}
-
-template <typename T>
-inline T abs(const T x) {
-    if (x < 0) {
-        return -x;
-    } else {
-        return x;
-    }
 }

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -781,7 +781,7 @@ describe('Daccustodian', () => {
           dacId,
           state_keys.total_votes_on_candidates
         );
-        chai.expect(actual).to.equal(40_000_000);
+        chai.expect(actual).to.equal(20_000_000);
       });
     });
     context('vote values after transfers', async () => {

--- a/contracts/daccustodian/privatehelpers.cpp
+++ b/contracts/daccustodian/privatehelpers.cpp
@@ -16,7 +16,7 @@ void daccustodian::updateVoteWeight(
         return; // trying to avoid throwing errors from here since it's unrelated to a transfer action.?!?!?!?!
     }
     registered_candidates.modify(candItr, same_payer, [&](auto &c) {
-        c.total_votes = S{c.total_votes} + S{weight};
+        c.total_votes = S<uint64_t>{c.total_votes}.to<int64_t>() + S{weight};
         if (from_voting) {
             if (c.total_votes == 0) {
                 c.avg_vote_time_stamp = time_point_sec(0);
@@ -35,7 +35,7 @@ time_point_sec daccustodian::calculate_avg_vote_time_stamp(const time_point_sec 
 
     const auto initial     = S{vote_time_before.sec_since_epoch()}.to<int128_t>();
     const auto current     = S{vote_time_stamp.sec_since_epoch()}.to<int128_t>();
-    const auto time_delta  = abs(current - initial);
+    const auto time_delta  = (current - initial).abs();
     const auto new_seconds = initial + time_delta * S{weight}.to<int128_t>() / S{total_votes}.to<int128_t>();
 
     return time_point_sec{new_seconds.to<uint32_t>()};

--- a/contracts/dacdirectory/dacdirectory.cpp
+++ b/contracts/dacdirectory/dacdirectory.cpp
@@ -13,8 +13,6 @@ namespace eosdac {
             map<uint8_t, string> refs, map<uint8_t, eosio::name> accounts) {
             require_auth(owner);
 
-            const vector<name> forbidden{
-                "admin"_n, "builder"_n, "members"_n, "dacauthority"_n, "daccustodian"_n, "eosdactokens"_n};
             check(std::find(forbidden.begin(), forbidden.end(), dac_id) == forbidden.end(),
                 "ERR::DAC_FORBIDDEN_NAME::DAC ID is forbidden");
             auto existing = _dacs.find(dac_id.value);

--- a/contracts/dacdirectory/dacdirectory.hpp
+++ b/contracts/dacdirectory/dacdirectory.hpp
@@ -42,6 +42,9 @@ namespace eosdac {
           private:
             void upsert_nft(const uint64_t id, const std::optional<name> old_owner_optional, const name new_owner);
 
+            static constexpr auto forbidden =
+                array{"admin"_n, "builder"_n, "members"_n, "dacauthority"_n, "daccustodian"_n, "eosdactokens"_n};
+
           protected:
             dac_table _dacs;
         };

--- a/contracts/safemath/safemath.test.ts
+++ b/contracts/safemath/safemath.test.ts
@@ -95,25 +95,25 @@ describe('Safemath', () => {
   it('convert1 should throw conversion overflow error', async () => {
     await assertEOSErrorIncludesMessage(
       contract.convert1(),
-      'conversion overflow'
+      'Invalid narrow cast'
     );
   });
   it('convert2 should throw Cannot convert negative value to unsigned error', async () => {
     await assertEOSErrorIncludesMessage(
       contract.convert2(),
-      'Cannot convert negative value to unsigned'
+      'Invalid narrow cast'
     );
   });
   it('convert3 should throw conversion overflow error', async () => {
     await assertEOSErrorIncludesMessage(
       contract.convert3(),
-      'conversion overflow'
+      'Invalid narrow cast'
     );
   });
   it('convert4 should throw conversion overflow error', async () => {
     await assertEOSErrorIncludesMessage(
       contract.convert4(),
-      'conversion overflow'
+      'Invalid narrow cast'
     );
   });
   it('xxx1 should throw conversion overflow error', async () => {
@@ -166,5 +166,20 @@ describe('Safemath', () => {
   });
   it('zzz2 should work', async () => {
     await contract.zzz2();
+  });
+  it('zzz3 should fail with signed multiplication overflow', async () => {
+    await assertEOSErrorIncludesMessage(
+      contract.zzz3(),
+      'signed multiplication overflow'
+    );
+  });
+  it('zzz4 should work', async () => {
+    await contract.zzz4();
+  });
+  it('zzz5 should work', async () => {
+    await contract.zzz5();
+  });
+  it('const1 should work', async () => {
+    await contract.const1();
   });
 });

--- a/contracts/stakevote/stakevote.cpp
+++ b/contracts/stakevote/stakevote.cpp
@@ -24,7 +24,7 @@ void stakevote::stakeobsv(const vector<account_stake_delta> &stake_deltas, const
     for (auto asd : stake_deltas) {
         const auto weight_delta_quorum = asd.stake_delta.amount;
         const auto weight_delta_s = S{asd.stake_delta.amount}.to<int128_t>() * S{asd.unstake_delay}.to<int128_t>() *
-                                    S{config.time_multiplier}.to<int128_t>() / S{time_divisor};
+                                    S{config.time_multiplier}.to<int128_t>() / time_divisor;
         const int64_t weight_delta = weight_delta_s.to<int64_t>();
         auto          vw_itr       = weights.find(asd.account.value);
         if (vw_itr != weights.end()) {
@@ -102,7 +102,7 @@ void stakevote::collectwts(uint16_t batch_size, uint32_t unstake_time, name dac_
         if (vw_itr == weights.end()) {
             const auto weight_delta_quorum = (stake->stake).amount;
             const auto weight_delta_s      = S{(stake->stake).amount}.to<int128_t>() * S{unstake_time}.to<int128_t>() *
-                                        S{config.time_multiplier}.to<int128_t>() / S{time_divisor};
+                                        S{config.time_multiplier}.to<int128_t>() / time_divisor;
             const int64_t weight_delta = weight_delta_s.to<int64_t>();
             weights.emplace(get_self(), [&](auto &v) {
                 v.voter         = stake->account;

--- a/contracts/stakevote/stakevote.hpp
+++ b/contracts/stakevote/stakevote.hpp
@@ -10,7 +10,7 @@ using namespace eosio;
 using namespace eosdac;
 using namespace std;
 
-static constexpr int128_t time_divisor{100000000};
+static constexpr auto time_divisor = S{10}.ipow(8).to<int128_t>();
 
 CONTRACT stakevote : public contract {
   public:
@@ -18,7 +18,7 @@ CONTRACT stakevote : public contract {
 
     struct [[eosio::table("config"), eosio::contract("stakevote")]] config_item {
         // time multiplier is measured in 10^-8 1 == 0.00000001
-        int64_t            time_multiplier = 100000000;
+        int64_t            time_multiplier = time_divisor;
         static config_item get_current_configs(eosio::name account, eosio::name scope) {
             check(config_container(account, scope.value).exists(), "Stake config not set.");
             return config_container(account, scope.value).get();

--- a/contracts/stakevote/stakevote.test.ts
+++ b/contracts/stakevote/stakevote.test.ts
@@ -328,11 +328,13 @@ describe('Stakevote', () => {
           chai.expect(x).to.equal(expected);
         });
         it('should update total_votes_on_candidates', async () => {
-          const expected = await get_expected_vote_weight(
-            stake_amount.amount_raw(),
-            2 * years,
-            dacId
-          );
+          const expected =
+            total_votes_on_candidates_before +
+            (await get_expected_vote_weight(
+              stake_amount.amount_raw(),
+              2 * years,
+              dacId
+            ));
           const x = await get_from_state2(
             dacId,
             state_keys.total_votes_on_candidates


### PR DESCRIPTION
* Safemath: More rigoruous type checking that will catch if one tries calculations with operands of a different type
* More clever design of operators to prevent downgrade to built-in operator for number types (while still allowing implicit conversion to of S to T) for ease-of-use/convenience.
* Rewrite of safe type conversion routine `.to<type>()` based on the C++ standards support library (GSL)
* Full constexpr support for safemath, allowing to define `static constexpr` variables at compile time while at the same time allowing to perform some calculations with them at comile time.
* The above safmath changes flagged a couple of errors in the project that no longer compiled and were fixed. Where code changes were necessary, some parts of that code were also cleaned up.
* Introduction of `narrow_cast<>()` to be used when the developer intentionally wants to make a lossy conversion to a narrower type. This is just an alias of `static_cast` but makes the developer’s intent abundantly clear for code reviewers and maintainers.
* Safemath test improvements to allow testing of compile-time contraints via std::experimental::is_detected_v declval/decltype trickery. Now tests fail if code that shouldn’t compile compiles or vice versa.
* Faster ipow algorithm for integers (O(log(n)) runtime instead of O(n)) while at the same time being safe from overflows.
* Various smaller cleanups