### PR TITLE
Refactor to msig.worlds to support flexible auth requests

### DIFF
--- a/contracts/msigworlds/msigworlds.cpp
+++ b/contracts/msigworlds/msigworlds.cpp
@@ -62,7 +62,7 @@ void multisig::propose(name proposer, name proposal_name, std::vector<permission
 
     auto packed_requested = pack(requested);
     auto res              = check_transaction_authorization(
-                     trx_pos, size, (const char *)0, 0, packed_requested.data(), packed_requested.size());
+        trx_pos, size, (const char *)0, 0, packed_requested.data(), packed_requested.size());
 
     check(res > 0, "msigworlds::propose preflight transaction authorization check failed");
 
@@ -98,7 +98,7 @@ void multisig::approve(
     }
 
     proposals proptable(get_self(), dac_id.value);
-    auto     &prop = proptable.get(proposal_name.value, "proposal not found");
+    auto &    prop = proptable.get(proposal_name.value, "proposal not found");
     check(prop.state == PropState::PENDING,
         "ERR::PROP_NOT_PENDING::proposal can only be approved while in pending state");
 
@@ -112,11 +112,15 @@ void multisig::approve(
         std::find_if(apps_it->requested_approvals.begin(), apps_it->requested_approvals.end(), [&](const approval &a) {
             return a.level == level;
         });
-    check(itr != apps_it->requested_approvals.end(), "approval is not on the list of requested approvals");
 
-    apptable.modify(apps_it, same_payer, [&](auto &a) {
+    auto        is_requested_approval = itr != apps_it->requested_approvals.end();
+    eosio::name ram_payer             = is_requested_approval ? same_payer : level.actor;
+
+    apptable.modify(apps_it, ram_payer, [&](auto &a) {
         a.provided_approvals.push_back(approval{level, current_time_point()});
-        a.requested_approvals.erase(itr);
+        if (is_requested_approval) {
+            a.requested_approvals.erase(itr);
+        }
     });
 
     transaction_header trx_header = get_trx_header(prop.packed_transaction.data(), prop.packed_transaction.size());
@@ -139,6 +143,15 @@ void multisig::approve(
 }
 
 void multisig::unapprove(name proposal_name, permission_level level, name dac_id) {
+    _unapprove(proposal_name, level, dac_id, true);
+}
+
+void multisig::deny(name proposal_name, permission_level level, name dac_id) {
+    _unapprove(proposal_name, level, dac_id, false);
+}
+
+void multisig::_unapprove(
+    name proposal_name, permission_level level, name dac_id, bool throw_if_not_previously_approved) {
     if (level.permission == "eosio.code"_n) {
         check(get_sender() == level.actor, "wrong contract sent `unapprove` action for eosio.code permmission");
     } else {
@@ -151,14 +164,17 @@ void multisig::unapprove(name proposal_name, permission_level level, name dac_id
         std::find_if(apps_it->provided_approvals.begin(), apps_it->provided_approvals.end(), [&](const approval &a) {
             return a.level == level;
         });
-    check(itr != apps_it->provided_approvals.end(), "no approval previously granted");
+
+    if (throw_if_not_previously_approved)
+        check(itr != apps_it->provided_approvals.end(), "no approval previously granted");
+
     apptable.modify(apps_it, same_payer, [&](auto &a) {
         a.requested_approvals.push_back(approval{level, current_time_point()});
         a.provided_approvals.erase(itr);
     });
 
     proposals proptable(get_self(), dac_id.value);
-    auto     &prop = proptable.get(proposal_name.value, "proposal not found");
+    auto &    prop = proptable.get(proposal_name.value, "proposal not found");
     check(prop.state == PropState::PENDING,
         "ERR::PROP_NOT_PENDING::proposal can only be changed while in pending state.");
 
@@ -178,51 +194,23 @@ void multisig::unapprove(name proposal_name, permission_level level, name dac_id
     });
 }
 
-void multisig::deny(name proposal_name, permission_level level, name dac_id) {
-    if (level.permission == "eosio.code"_n) {
-        check(get_sender() == level.actor, "wrong contract sent `deny` action for eosio.code permmission");
-    } else {
-        require_auth(level);
-    }
-
-    approvals apptable(get_self(), dac_id.value);
-    auto      apps_it = apptable.find(proposal_name.value);
-    auto      itr =
-        std::find_if(apps_it->provided_approvals.begin(), apps_it->provided_approvals.end(), [&](const approval &a) {
-            return a.level == level;
-        });
-    if (itr != apps_it->provided_approvals.end()) {
-        apptable.modify(apps_it, same_payer, [&](auto &a) {
-            a.requested_approvals.push_back(approval{level, current_time_point()});
-            a.provided_approvals.erase(itr);
-        });
-    }
+void multisig::checkauth(name proposal_name, name dac_id) {
     proposals proptable(get_self(), dac_id.value);
-    auto     &prop = proptable.get(proposal_name.value, "proposal not found");
-    check(
-        prop.state == PropState::PENDING, "ERR::PROP_NOT_PENDING::proposal can only be denied while in pending state.");
-
-    if (prop.earliest_exec_time.has_value()) {
-        auto table_op = [](auto &&, auto &&) {};
-        if (!trx_is_authorized(
-                get_approvals_and_adjust_table(get_self(), proposal_name, table_op, dac_id), prop.packed_transaction)) {
-            proptable.modify(prop, same_payer, [&](auto &p) {
-                p.earliest_exec_time = std::optional<time_point>{};
-            });
-        }
+    auto &    prop     = proptable.get(proposal_name.value, "proposal not found");
+    auto      table_op = [](auto &&, auto &&) {};
+    if (trx_is_authorized(
+            get_approvals_and_adjust_table(get_self(), proposal_name, table_op, dac_id), prop.packed_transaction)) {
+        check(false, "Approved: Transaction has sufficient approvals to execute");
+    } else {
+        check(false, "Unapproved: Transaction has insufficient to approvals to execute");
     }
-
-    auto prop_itr = proptable.iterator_to(prop);
-    proptable.modify(prop_itr, same_payer, [&](proposal &p) {
-        p.modified_date = current_time_point();
-    });
 }
 
 void multisig::cancel(name proposal_name, name canceler, name dac_id) {
     require_auth(canceler);
 
     proposals proptable(get_self(), dac_id.value);
-    auto     &prop = proptable.get(proposal_name.value, "proposal not found");
+    auto &    prop = proptable.get(proposal_name.value, "proposal not found");
 
     if (canceler != prop.proposer) {
         check(unpack<transaction_header>(prop.packed_transaction).expiration <
@@ -237,19 +225,13 @@ void multisig::cancel(name proposal_name, name canceler, name dac_id) {
         p.modified_date = current_time_point();
         p.state         = PropState::CANCELLED;
     });
-
-    // proptable.erase(prop);
-
-    // approvals apptable(get_self(), dac_id.value);
-    // auto apps_it = apptable.require_find(proposal_name.value, "ERR::NO_APPROVALS_FOUND::No approvals were
-    // found."); apptable.erase(apps_it);
 }
 
 void multisig::exec(name proposal_name, name executer, name dac_id) {
     require_auth(executer);
 
     proposals proptable(get_self(), dac_id.value);
-    auto     &prop = proptable.get(proposal_name.value, "proposal not found");
+    auto &    prop = proptable.get(proposal_name.value, "proposal not found");
     check(prop.state == PropState::PENDING,
         "ERR::PROP_EXEC_NOT_PENDING::The same proposal cannot be executed mulitple times.");
 
@@ -288,7 +270,7 @@ void multisig::exec(name proposal_name, name executer, name dac_id) {
 
 void multisig::cleanup(name proposal_name, name dac_id) {
     proposals proptable(get_self(), dac_id.value);
-    auto     &prop = proptable.get(proposal_name.value, "ERR::PROPOSAL_NOT_FOUND::proposal not found");
+    auto &    prop = proptable.get(proposal_name.value, "ERR::PROPOSAL_NOT_FOUND::proposal not found");
     check(prop.state != PropState::PENDING,
         "ERR::PROPOSAL_CLEANUP_STILL_PENDING::proposal cannot be cleared before being executed or cancelled.");
 

--- a/contracts/msigworlds/msigworlds.cpp
+++ b/contracts/msigworlds/msigworlds.cpp
@@ -165,13 +165,17 @@ void multisig::_unapprove(
             return a.level == level;
         });
 
-    if (throw_if_not_previously_approved)
-        check(itr != apps_it->provided_approvals.end(), "no approval previously granted");
+    auto approvals_previously_granted = itr != apps_it->provided_approvals.end();
 
-    apptable.modify(apps_it, same_payer, [&](auto &a) {
-        a.requested_approvals.push_back(approval{level, current_time_point()});
-        a.provided_approvals.erase(itr);
-    });
+    if (throw_if_not_previously_approved)
+        check(approvals_previously_granted, "no approval previously granted");
+
+    if (approvals_previously_granted) {
+        apptable.modify(apps_it, same_payer, [&](auto &a) {
+            a.requested_approvals.push_back(approval{level, current_time_point()});
+            a.provided_approvals.erase(itr);
+        });
+    }
 
     proposals proptable(get_self(), dac_id.value);
     auto &    prop = proptable.get(proposal_name.value, "proposal not found");

--- a/contracts/msigworlds/msigworlds.test.ts
+++ b/contracts/msigworlds/msigworlds.test.ts
@@ -7,8 +7,6 @@ import {
   assertMissingAuthority,
   EOSManager,
   sleep,
-  debugPromise,
-  assertRowsEqualStrict,
   assertRowCount,
 } from 'lamington';
 import { SharedTestObjects } from '../TestHelpers';
@@ -36,7 +34,7 @@ export const currentHeadTimeWithAddedSeconds = async (seconds: number) => {
   return date;
 };
 
-describe('msigworlds', () => {
+describe.only('msigworlds', () => {
   let shared: SharedTestObjects;
 
   before(async () => {
@@ -416,16 +414,13 @@ describe('msigworlds', () => {
     });
     context('with existing proposal', async () => {
       context('for unrequested auth', async () => {
-        it('should fail with approval not on list found error', async () => {
-          await assertEOSErrorIncludesMessage(
-            msigworlds.approve(
-              'prop1',
-              { actor: owner3.name, permission: 'active' },
-              'dac1',
-              null,
-              { from: owner3 }
-            ),
-            'approval is not on the list of requested approvals'
+        it('should succeed', async () => {
+          await msigworlds.approve(
+            'prop1',
+            { actor: owner3.name, permission: 'active' },
+            'dac1',
+            null,
+            { from: owner3 }
           );
         });
       });
@@ -453,7 +448,8 @@ describe('msigworlds', () => {
           expect(matching.requested_approvals[0].time).to.equal(
             '1970-01-01T00:00:00.000'
           );
-          expect(matching.provided_approvals[0].level.actor).to.equal('owner2');
+          expect(matching.provided_approvals[0].level.actor).to.equal('owner3');
+          expect(matching.provided_approvals[1].level.actor).to.equal('owner2');
           expect(new Date(matching.provided_approvals[0].time)).to.afterDate(
             new Date('2022-01-01T00:00:00.000')
           );
@@ -506,9 +502,9 @@ describe('msigworlds', () => {
             await assertEOSErrorIncludesMessage(
               msigworlds.unapprove(
                 'prop1',
-                { actor: owner3.name, permission: 'active' },
+                { actor: owner1.name, permission: 'active' },
                 'dac1',
-                { from: owner3 }
+                { from: owner1 }
               ),
               'no approval previously granted'
             );
@@ -537,7 +533,7 @@ describe('msigworlds', () => {
             expect(matching.requested_approvals[0].time).to.equal(
               '1970-01-01T00:00:00.000'
             );
-            expect(matching.provided_approvals).to.empty;
+            expect(matching.provided_approvals.length).to.equal(1);
             expect(matching.requested_approvals[1].level.actor).to.equal(
               'owner2'
             );
@@ -580,7 +576,7 @@ describe('msigworlds', () => {
               'dac1',
               { from: owner1 }
             ),
-            'proposal not found'
+            'ERR::NO_APPROVALS_FOUND'
           );
         });
       });


### PR DESCRIPTION
Previously all requested auths needed to be explicitly specified. 
eg. a txn for `dacaccount@active` would require `cust1@active`, `cust2@active`, `cust3@active`, `cust4@active`. 
But since the custodians could change between periods while an MSIG is still live the MSIG would need to specify cust1, cust2, cust3, cust4...cust8 to be confident to have enough auths to cover for election changes of custodians. But even then could still miss out on the required custodians to approve a txn.

* This change allows the MSIG to be proposed with the top level requested auth eg. `dacaccount@active` only so it can be dynamically checked during execution.

* Also adds a `checkauth` action that will test if the provided auths satisfy the required auth to execute the transaction. This throws an error in both true and false cases to prevent spamming the chain with a `read-only` action but the error will display the result.

* Last change is a refactor of the `unapprove` and `deny` actions to DRY up the code which has the same logic except that one throws an error if the user has not previously approved an MSIG.