### PR TITLE
Simplify custodian unstaking

### DIFF
--- a/contract-shared-headers/common_utilities.hpp
+++ b/contract-shared-headers/common_utilities.hpp
@@ -58,7 +58,7 @@ inline std::string toString(const T &x) {
     if constexpr (std::is_same<T, std::string>::value) {
         return x;
     } else if constexpr (std::is_same<T, eosio::symbol>::value) {
-        return x.code().to_string();
+        return std::to_string(x.precision()) + "," + x.code().to_string();
     } else if constexpr (has_to_string<T>::value) {
         return x.to_string();
     } else {

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -119,7 +119,7 @@ namespace eosdac {
         eosio::asset          locked_tokens;
         uint64_t              total_votes;
         uint8_t               is_active;
-        eosio::time_point_sec custodian_end_time_stamp;
+        eosio::time_point_sec custodian_end_time_stamp; // currently unused
         eosio::time_point_sec avg_vote_time_stamp;
 
         uint64_t by_decayed_votes() const {
@@ -224,11 +224,11 @@ namespace eosdac {
     struct [[eosio::table("state2"), eosio::contract("daccustodian")]] contr_state2 {
         eosio::time_point_sec                  lastperiodtime = time_point_sec(0);
         std::map<uint8_t, state_value_variant> data           = {
-            {state_keys::total_weight_of_votes, int64_t(0)},
-            {state_keys::total_votes_on_candidates, int64_t(0)},
-            {state_keys::number_active_candidates, uint32_t(0)},
-            {state_keys::met_initial_votes_threshold, false},
-            {state_keys::lastclaimbudgettime, time_point_sec(0)},
+                      {state_keys::total_weight_of_votes, int64_t(0)},
+                      {state_keys::total_votes_on_candidates, int64_t(0)},
+                      {state_keys::number_active_candidates, uint32_t(0)},
+                      {state_keys::met_initial_votes_threshold, false},
+                      {state_keys::lastclaimbudgettime, time_point_sec(0)},
         };
 
         static contr_state2 get_current_state(const eosio::name account, const eosio::name scope) {

--- a/contracts/daccustodian/config.cpp
+++ b/contracts/daccustodian/config.cpp
@@ -32,6 +32,11 @@ ACTION daccustodian::updateconfige(const contr_config &new_config, const name &d
         check(dacForScope.account_for_type_maybe(dacdir::SERVICE).has_value(),
             "ERR::UPDATECONFIG_NO_SERVICE_ACCOUNT should_pay_via_service_provider is true, but no SERVICE account is set.");
     }
+
+    check(new_config.lockupasset.quantity.symbol == dacForScope.symbol.get_symbol(),
+        "Symbol mismatch dac symbol is %s but symbol given is %s", dacForScope.symbol.get_symbol(),
+        new_config.lockupasset.quantity.symbol);
+
     auto globals = dacglobals::current(get_self(), dac_id);
 
     globals.set_lockupasset(new_config.lockupasset);

--- a/contracts/daccustodian/external_observable_actions.cpp
+++ b/contracts/daccustodian/external_observable_actions.cpp
@@ -70,23 +70,11 @@ void daccustodian::validateUnstakeAmount(
     const name &code, const name &cand, const asset &unstake_amount, const name &dac_id) {
     // Will assert if adc_id not found
     check(unstake_amount.amount > 0, "ERR::NEGATIVE_UNSTAKE::Unstake amount must be positive");
-    auto dac            = dacdir::dac_for_id(dac_id);
-    auto token_contract = dac.symbol.get_contract();
 
-    candidates_table registered_candidates(code, dac_id.value);
-    auto             reg_candidate = registered_candidates.find(cand.value);
+    const auto registered_candidates = candidates_table{code, dac_id.value};
+    const auto reg_candidate         = registered_candidates.find(cand.value);
     if (reg_candidate != registered_candidates.end()) {
-        extended_asset lockup_asset  = dacglobals::current(code, dac_id).get_lockupasset();
-        auto           current_stake = eosdac::get_staked(cand, token_contract, unstake_amount.symbol);
-
-        print(" Current stake : ", current_stake, ", Unstake amount : ", unstake_amount);
         check(!reg_candidate->is_active,
             "ERR::CANNOT_UNSTAKE_REGISTERED::Cannot unstake because you are registered as a candidate, use withdrawcane to unregister.");
-
-        if (reg_candidate->custodian_end_time_stamp > time_point_sec(eosio::current_time_point())) {
-            // Still under restrictions
-            check(current_stake >= lockup_asset.quantity,
-                "ERR::CANNOT_UNSTAKE::Cannot unstake because stake is locked by the custodian agreement");
-        }
     }
 }

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -85,7 +85,6 @@ void daccustodian::allocateCustodians(bool early_election, name dac_id) {
                 "ERR::NEWPERIOD_EXPECTED_CAND_NOT_FOUND::Corrupt data: Trying to set a lockup delay on candidate leaving office.");
             registered_candidates.modify(reg_candidate, same_payer, [&](candidate &c) {
                 eosio::print("Lockup stake for release delay.");
-                c.custodian_end_time_stamp = now() + globals.get_lockup_release_time_delay();
             });
             cust_itr = custodians.erase(cust_itr);
         }
@@ -108,11 +107,6 @@ void daccustodian::allocateCustodians(bool early_election, name dac_id) {
                 c.cust_name    = cand_itr->candidate_name;
                 c.requestedpay = cand_itr->requestedpay;
                 c.total_votes  = cand_itr->total_votes;
-            });
-
-            byvotes.modify(cand_itr, same_payer, [&](candidate &c) {
-                eosio::print("Lockup stake for release delay.");
-                c.custodian_end_time_stamp = now() + globals.get_lockup_release_time_delay();
             });
 
             currentCustodianCount++;


### PR DESCRIPTION
When custodian registers, validate that staketime is at least lockup_release_time_delay. Once candidate is no longer active, allow unstaking immediately. No longer rely on custodian_end_time_stamp. That field is now still present in the table, but unused.