### PR TITLE
Cu 2u55f5t eosdac fix remove candidate action

### DIFF
--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -2112,6 +2112,16 @@ describe('Daccustodian', () => {
             .expect(numberActiveCandidatesAfter)
             .to.be.equal(numberActiveCandidatesBefore - 1);
         });
+        it('withdrawing the same candidate twice should fail', async () => {
+          await assertEOSErrorIncludesMessage(
+            shared.daccustodian_contract.withdrawcane(
+              unelectedCandidateToResign.name,
+              dacId,
+              { from: unelectedCandidateToResign }
+            ),
+            'ERR::REMOVECANDIDATE_CANDIDATE_NOT_ACTIVE'
+          );
+        });
         it('should allow unstaking without a timelock error', async () => {
           await shared.dac_token_contract.unstake(
             unelectedCandidateToResign.name,


### PR DESCRIPTION
fix unsigned integer wraparound below zero cause by bug that allowed candidates to be remove more than once