### PR TITLE
Cu 2xbq8yy add vote count to votes in daoworlds

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -276,6 +276,7 @@ namespace eosdac {
         name                  proxy;
         std::vector<name>     candidates;
         eosio::time_point_sec vote_time_stamp;
+        uint8_t               vote_count; // wraps around automatically if > 255
 
         uint64_t primary_key() const {
             return voter.value;

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -957,12 +957,14 @@ describe('Daccustodian', () => {
           .expect(rows[0].candidates)
           .deep.equal([cands[0].name, cands[2].name]);
         chai.expect(rows[0].proxy).to.equal('');
+        chai.expect(rows[0].vote_count).to.equal(0);
         expect_recent(rows[0].vote_time_stamp);
         chai
           .expect(rows[1].candidates)
           .deep.equal([cands[0].name, cands[2].name]);
         chai.expect(rows[1].proxy).to.equal('');
         expect_recent(rows[1].vote_time_stamp);
+        chai.expect(rows[1].vote_count).to.equal(0);
       });
       it('only candidates with votes have total_votes values', async () => {
         let unvotedCandidateResult =
@@ -998,6 +1000,86 @@ describe('Daccustodian', () => {
         chai.expect(actual).to.equal(20_000_000);
       });
       it('state should have increased the total_votes_on_candidates', async () => {
+        const actual = await get_from_dacglobals(
+          dacId,
+          'total_votes_on_candidates'
+        );
+        chai.expect(actual).to.equal(20_000_000);
+      });
+    });
+    context('After same users voting again', async () => {
+      before(async () => {
+        // Place votes for even number candidates and leave odd number without votes.
+        // Only vote with the first 2 members
+        for (const member of regMembers.slice(0, 2)) {
+          await debugPromise(
+            shared.daccustodian_contract.votecust(
+              member.name,
+              [cands[0].name, cands[2].name],
+              dacId,
+              { from: member }
+            ),
+            'voting custodian'
+          );
+        }
+      });
+      it('votes table should have rows', async () => {
+        const res = await shared.daccustodian_contract.votesTable({
+          scope: dacId,
+        });
+        const rows = res.rows;
+        chai
+          .expect(rows.map((x) => x.voter))
+          .to.deep.equalInAnyOrder(regMembers.slice(0, 2).map((x) => x.name));
+
+        chai
+          .expect(rows[0].candidates)
+          .deep.equal([cands[0].name, cands[2].name]);
+        chai.expect(rows[0].proxy).to.equal('');
+        chai.expect(rows[0].vote_count).to.equal(1);
+        expect_recent(rows[0].vote_time_stamp);
+        chai
+          .expect(rows[1].candidates)
+          .deep.equal([cands[0].name, cands[2].name]);
+        chai.expect(rows[1].proxy).to.equal('');
+        expect_recent(rows[1].vote_time_stamp);
+
+        chai.expect(rows[1].vote_count).to.equal(1);
+      });
+      it('only candidates with votes have total_votes values', async () => {
+        let unvotedCandidateResult =
+          await shared.daccustodian_contract.candidatesTable({
+            scope: dacId,
+            limit: 1,
+            lowerBound: cands[1].name,
+          });
+
+        chai.expect(unvotedCandidateResult.rows[0].total_votes).to.equal(0);
+        let votedCandidateResult =
+          await shared.daccustodian_contract.candidatesTable({
+            scope: dacId,
+            limit: 1,
+            lowerBound: cands[0].name,
+          });
+
+        chai.expect(votedCandidateResult.rows[0]).to.include({
+          total_votes: 20_000_000,
+        });
+        await assertRowCount(
+          shared.daccustodian_contract.votesTable({
+            scope: dacId,
+          }),
+          2
+        );
+      });
+      it('state should not have increased the total_weight_of_votes', async () => {
+        const actual = await get_from_dacglobals(
+          dacId,
+          'total_weight_of_votes'
+        );
+        chai.expect(actual).to.equal(20_000_000);
+      });
+      it('state should not have increased the total_votes_on_candidates', async () => {
         const actual = await get_from_dacglobals(
           dacId,
           'total_votes_on_candidates'

--- a/contracts/daccustodian/voting.cpp
+++ b/contracts/daccustodian/voting.cpp
@@ -41,6 +41,7 @@ ACTION daccustodian::votecust(const name &voter, const vector<name> &newvotes, c
                 v.candidates      = newvotes;
                 v.proxy           = name();
                 v.vote_time_stamp = now();
+                v.vote_count++;
             });
         }
     } else {
@@ -51,6 +52,7 @@ ACTION daccustodian::votecust(const name &voter, const vector<name> &newvotes, c
             v.voter           = voter;
             v.candidates      = newvotes;
             v.vote_time_stamp = now();
+            v.vote_count      = 0;
         });
     }
 }


### PR DESCRIPTION
Simple change, yet once thing is noteworthy. I decided to use uint8_t for the vote_count. It can only hold numbers up to 255 and will wrap around back to zero afterwards, but I think in this case, it's perfectly sufficient.