### PR TITLE
Removes unused `id` field from msig proposals. 

### DIFF
--- a/contracts/msigworlds/msigworlds.cpp
+++ b/contracts/msigworlds/msigworlds.cpp
@@ -70,7 +70,6 @@ void multisig::propose(name proposer, name proposal_name, std::vector<permission
     const auto pkd_trans = std::vector<char>(trx_pos, trx_pos + size);
 
     proptable.emplace(proposer, [&](proposal &prop) {
-        prop.id                 = next_id(dac_id);
         prop.proposal_name      = proposal_name;
         prop.proposer           = proposer;
         prop.packed_transaction = pkd_trans;
@@ -315,14 +314,6 @@ void multisig::blockaction(name account, name action, name dac_id) {
         a.account = account;
         a.action  = action;
     });
-}
-
-uint64_t multisig::next_id(name dac_id) {
-    auto s = serial_singleton{_self, dac_id.value};
-    auto x = s.get_or_create(get_self(), serial());
-    x.id++;
-    s.set(x, get_self());
-    return x.id;
 }
 
 transaction_header get_trx_header(const char *ptr, size_t sz) {

--- a/contracts/msigworlds/msigworlds.hpp
+++ b/contracts/msigworlds/msigworlds.hpp
@@ -14,7 +14,6 @@ using namespace eosio;
 enum PropState { PENDING = 0, EXECUTED = 1, CANCELLED = 2 };
 
 struct [[eosio::table("proposals"), eosio::contract("msigworlds")]] proposal {
-    uint64_t                           id;
     name                               proposal_name;
     name                               proposer;
     std::vector<char>                  packed_transaction;
@@ -82,11 +81,6 @@ struct [[eosio::table("blockedactns"), eosio::contract("msigworlds")]] blocked_a
 typedef eosio::multi_index<"blockedactns"_n, blocked_action,
     indexed_by<"contractns"_n, const_mem_fun<blocked_action, uint128_t, &blocked_action::contract_and_actions>>>
     blocked_actions;
-
-TABLE serial {
-    uint64_t id = 0;
-};
-using serial_singleton = eosio::singleton<"serial"_n, serial>;
 
 /**
  * The `eosio.msig` system contract allows for creation of proposed transactions which require authorization from a
@@ -236,8 +230,7 @@ class [[eosio::contract("msigworlds")]] multisig : public eosio::contract {
     using invalidate_action = eosio::action_wrapper<"invalidate"_n, &multisig::invalidate>;
 
   private:
-    uint64_t next_id(name dac_id);
-    void     _unapprove(name proposal_name, permission_level level, name dac_id, bool throw_if_not_previously_approved);
+    void _unapprove(name proposal_name, permission_level level, name dac_id, bool throw_if_not_previously_approved);
 
     void assertValidMember(const name proposer, const name dac_id) {
         const auto dac                 = eosdac::dacdir::dac_for_id(dac_id);

--- a/contracts/msigworlds/msigworlds.test.ts
+++ b/contracts/msigworlds/msigworlds.test.ts
@@ -349,7 +349,6 @@ describe('msigworlds', () => {
             expect(prop.proposer).to.equal(owner1.name);
             expect(prop.state).to.equal(0);
             expect(prop.proposal_name).to.equal('prop1');
-            expect(prop.id).to.equal(1);
             modDate = prop.modified_date;
           });
           it('should populate approvals table', async () => {
@@ -811,7 +810,6 @@ describe('msigworlds', () => {
       });
       const prop = res.rows[0];
       expect(prop.proposal_name).to.equal('prop2');
-      expect(prop.id).to.equal(2);
     });
     context('with wrong auth', async () => {
       it('should fail with auth error', async () => {
@@ -910,7 +908,6 @@ describe('msigworlds', () => {
         });
         const prop = res.rows[0];
         expect(prop.proposal_name).to.equal('propexp');
-        expect(prop.id).to.equal(3);
       });
       it('should fail with expired error', async () => {
         await assertEOSErrorIncludesMessage(
@@ -990,7 +987,6 @@ describe('msigworlds', () => {
         });
         const prop = res.rows[0];
         expect(prop.proposal_name).to.equal('propgood');
-        expect(prop.id).to.equal(4);
       });
 
       it('should update approvals table', async () => {
@@ -1101,7 +1097,6 @@ describe('msigworlds', () => {
         });
         const prop = res.rows[0];
         expect(prop.proposal_name).to.equal('propclean');
-        expect(prop.id).to.equal(5);
       });
       it('shoul fail with wrong state error', async () => {
         await assertEOSErrorIncludesMessage(


### PR DESCRIPTION
Having this creates confusion since the foreign key used in the approvals table is proposal_name and it's better to just have one obvious primary key as the proposal_name rather than id.