### PR TITLE
Refactor eosdac tests to allow token issuer that is not the token contract itself

### DIFF
--- a/contracts/TestHelpers.ts
+++ b/contracts/TestHelpers.ts
@@ -70,6 +70,7 @@ export class SharedTestObjects {
   private async initAndGetSharedObjects() {
     console.log('Init eos blockchain');
     await sleep(1000);
+    this.tokenIssuer = await AccountManager.createAccount('federation');
     await this.configTokenContract();
 
     // EOSManager.initWithDefaults();
@@ -225,11 +226,11 @@ export class SharedTestObjects {
       .concat(
         newMembers.map((account) => {
           return this.dac_token_contract.transfer(
-            this.dac_token_contract.account.name,
+            this.tokenIssuer,
             account.name,
             initialDacAsset,
             '',
-            { from: this.dac_token_contract.account }
+            { from: this.tokenIssuer }
           );
         })
       );
@@ -285,16 +286,16 @@ export class SharedTestObjects {
 
   private async setup_tokens(initialAsset: string) {
     await this.dac_token_contract.create(
-      this.dac_token_contract.account.name,
+      this.tokenIssuer.name,
       initialAsset,
       false,
       { from: this.dac_token_contract.account }
     );
     await this.dac_token_contract.issue(
-      this.dac_token_contract.account.name,
+      this.tokenIssuer.name,
       initialAsset,
       'Initial Token holder',
-      { from: this.dac_token_contract.account }
+      { from: this.tokenIssuer }
     );
   }
 
@@ -890,11 +891,11 @@ export class SharedTestObjects {
   }
 
   async configTokenContract() {
-    this.eosio_token_contract = await ContractDeployer.deployWithName<
-      EosioToken
-    >('eosio.token', 'alien.worlds');
-
-    this.tokenIssuer = await AccountManager.createAccount('federation');
+    this.eosio_token_contract =
+      await ContractDeployer.deployWithName<EosioToken>(
+        'eosio.token',
+        'alien.worlds'
+      );
 
     try {
       await this.eosio_token_contract.create(

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -678,13 +678,13 @@ describe('Daccustodian', () => {
             );
             await debugPromise(
               shared.dac_token_contract.transfer(
-                shared.dac_token_contract.account.name,
+                shared.tokenIssuer.name,
                 newUser1.name,
                 '1000.00 NOMDAC',
                 '',
-                { from: shared.dac_token_contract.account }
+                { from: shared.tokenIssuer }
               ),
-              'failed to preload the user with enough tokens for staking'
+              'failed to preload the user with enough tokens for staking y'
             );
             await debugPromise(
               shared.dac_token_contract.stake(newUser1.name, '1000.00 NOMDAC', {
@@ -736,13 +736,13 @@ describe('Daccustodian', () => {
           before(async () => {
             await debugPromise(
               shared.dac_token_contract.transfer(
-                shared.dac_token_contract.account.name,
+                shared.tokenIssuer,
                 newUser1.name,
                 '12.00 NOMDAC',
                 '',
-                { from: shared.dac_token_contract.account }
+                { from: shared.tokenIssuer }
               ),
-              'failed to preload the user with enough tokens for staking'
+              'failed to preload the user with enough tokens for staking x'
             );
             await debugPromise(
               shared.dac_token_contract.stake(newUser1.name, '12.00 NOMDAC', {

--- a/contracts/dacproposals/dacproposals.test.ts
+++ b/contracts/dacproposals/dacproposals.test.ts
@@ -860,12 +860,12 @@ describe('Dacproposals', () => {
           name: 'transfer',
           authorization: [
             {
-              actor: shared.dac_token_contract.account.name,
+              actor: shared.tokenIssuer.name,
               permission: 'active',
             },
           ],
           data: {
-            from: shared.dac_token_contract.account.name,
+            from: shared.tokenIssuer.name,
             to: shared.treasury_account.name,
             quantity: '100000.0000 PROPDAC',
             memo: 'initial funds for proposal payments',
@@ -2592,19 +2592,19 @@ describe('Dacproposals', () => {
 async function setup_test_user(testuser: Account, tokenSymbol: string) {
   // const testuser = await AccountManager.createAccount('clienttest');
   await shared.dac_token_contract.transfer(
-    shared.dac_token_contract.account.name,
+    shared.tokenIssuer.name,
     testuser.name,
     `1200.0000 ${tokenSymbol}`,
     '',
-    { from: shared.dac_token_contract.account }
+    { from: shared.tokenIssuer }
   );
 
   await shared.dac_token_contract.transfer(
-    shared.dac_token_contract.account.name,
+    shared.tokenIssuer.name,
     planet.name,
     `1200.0000 PROPDAC`,
     '',
-    { from: shared.dac_token_contract.account }
+    { from: shared.tokenIssuer }
   );
 }
 

--- a/contracts/referendum/referendum.test.ts
+++ b/contracts/referendum/referendum.test.ts
@@ -387,18 +387,18 @@ describe('referendum', () => {
 
 async function setup_token() {
   await shared.dac_token_contract.transfer(
-    shared.dac_token_contract.account.name,
+    shared.tokenIssuer.name,
     user1.name,
     '1100.0000 REF',
     'starter blanace.',
-    { from: shared.dac_token_contract.account }
+    { from: shared.tokenIssuer }
   );
   await shared.dac_token_contract.transfer(
-    shared.dac_token_contract.account.name,
+    shared.tokenIssuer.name,
     planet.name,
     '1100.0000 REF',
     'starter blanace.',
-    { from: shared.dac_token_contract.account }
+    { from: shared.tokenIssuer }
   );
   await shared.dac_token_contract.stakeconfig(
     { enabled: true, min_stake_time: 5, max_stake_time: 20 },

--- a/contracts/stakevote/stakevote.test.ts
+++ b/contracts/stakevote/stakevote.test.ts
@@ -85,11 +85,11 @@ describe('Stakevote', () => {
       });
       it('should work', async () => {
         await shared.dac_token_contract.transfer(
-          shared.dac_token_contract.account.name,
+          shared.tokenIssuer.name,
           staker.name,
           stake_amount,
           '',
-          { from: shared.dac_token_contract.account }
+          { from: shared.tokenIssuer }
         );
 
         await shared.dac_token_contract.stake(staker.name, stake_amount, {
@@ -266,14 +266,13 @@ describe('Stakevote', () => {
               );
             });
             it('Should have highest ranked votes in custodians', async () => {
-              let rowsResult = await shared.daccustodian_contract.custodiansTable(
-                {
+              let rowsResult =
+                await shared.daccustodian_contract.custodiansTable({
                   scope: dacId,
                   limit: 14,
                   indexPosition: 3,
                   keyType: 'i64',
-                }
-              );
+                });
               let rs = rowsResult.rows;
               rs.sort((a, b) => {
                 return a.total_votes < b.total_votes
@@ -350,7 +349,8 @@ describe('Stakevote', () => {
             dacId,
             'total_votes_on_candidates'
           );
-          total_votes_on_candidates_beginning = total_votes_on_candidates_before;
+          total_votes_on_candidates_beginning =
+            total_votes_on_candidates_before;
         });
         it('should work', async () => {
           const cust1 = candidates[0];
@@ -573,11 +573,11 @@ async function setup_permissions() {
 
 async function stake(user: Account, amount: string) {
   await shared.dac_token_contract.transfer(
-    shared.dac_token_contract.account.name,
+    shared.tokenIssuer.name,
     user.name,
     amount,
     '',
-    { from: shared.dac_token_contract.account }
+    { from: shared.tokenIssuer }
   );
   await shared.dac_token_contract.stake(user.name, amount, {
     from: user,


### PR DESCRIPTION
The eosdac tests assumed in many places that the issuer of tokens is always the token contract itself. The testing code was refactored to allow for setting a different token issuer and that issuer was set to an account named "federation". This now matches what is deployed on mainnet.