### PR TITLE
Adds number_voters to count number of voters for each candidate

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -94,14 +94,14 @@ namespace eosdac {
     struct [[eosio::table("custodians"), eosio::contract("daccustodian")]] custodian {
         eosio::name  cust_name;
         eosio::asset requestedpay;
-        uint64_t     total_votes;
+        uint64_t     total_vote_power;
 
         uint64_t primary_key() const {
             return cust_name.value;
         }
 
         uint64_t by_votes_rank() const {
-            return UINT64_MAX - total_votes;
+            return UINT64_MAX - total_vote_power;
         }
 
         uint64_t by_requested_pay() const {
@@ -117,14 +117,14 @@ namespace eosdac {
         eosio::name           candidate_name;
         eosio::asset          requestedpay;
         eosio::asset          locked_tokens;
-        uint64_t              total_votes;
+        uint64_t              total_vote_power;
         uint8_t               is_active;
-        eosio::time_point_sec custodian_end_time_stamp; // currently unused
+        uint32_t              number_voters;
         eosio::time_point_sec avg_vote_time_stamp;
 
         uint64_t by_decayed_votes() const {
             // log(0) is -infinity, so we always add 1. This does not change the order of the index.
-            const auto log_arg = S{total_votes} + S{1ull};
+            const auto log_arg = S{total_vote_power} + S{1ull};
             const auto log     = log2(log_arg.to<double>());
             const auto x =
                 S{log} + S{avg_vote_time_stamp.sec_since_epoch()}.to<double>() / S{SECONDS_TO_DOUBLE}.to<double>();
@@ -136,10 +136,10 @@ namespace eosdac {
             return candidate_name.value;
         }
         uint64_t by_number_votes() const {
-            return total_votes;
+            return total_vote_power;
         }
         uint64_t by_votes_rank() const {
-            return S{UINT64_MAX} - S{total_votes};
+            return S{UINT64_MAX} - S{total_vote_power};
         }
         uint64_t by_requested_pay() const {
             return S{requestedpay.amount}.to<uint64_t>();

--- a/contracts/daccustodian/debug.cpp
+++ b/contracts/daccustodian/debug.cpp
@@ -29,7 +29,8 @@ void daccustodian::resetcands(const name &dac_id) {
 
     while (cand != candidates.end()) {
         candidates.modify(cand, same_payer, [&](candidate &c) {
-            c.total_votes         = 0;
+            c.total_vote_power    = 0;
+            c.number_voters       = 0;
             c.avg_vote_time_stamp = eosio::time_point_sec();
         });
 

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -96,7 +96,7 @@ void daccustodian::allocateCustodians(bool early_election, name dac_id) {
     }
 
     while (currentCustodianCount < electcount) {
-        check(cand_itr != byvotes.end() && cand_itr->total_votes > 0,
+        check(cand_itr != byvotes.end() && cand_itr->total_vote_power > 0,
             "ERR::NEWPERIOD_NOT_ENOUGH_CANDIDATES::There are not enough eligible candidates to run new period without causing potential lock out permission structures for this DAC.");
 
         //  If the candidate is inactive or is already a custodian skip to the next one.
@@ -104,9 +104,9 @@ void daccustodian::allocateCustodians(bool early_election, name dac_id) {
             cand_itr++;
         } else {
             custodians.emplace(auth_account, [&](custodian &c) {
-                c.cust_name    = cand_itr->candidate_name;
-                c.requestedpay = cand_itr->requestedpay;
-                c.total_votes  = cand_itr->total_votes;
+                c.cust_name        = cand_itr->candidate_name;
+                c.requestedpay     = cand_itr->requestedpay;
+                c.total_vote_power = cand_itr->total_vote_power;
             });
 
             currentCustodianCount++;
@@ -145,7 +145,7 @@ void daccustodian::add_auth_to_account(const name &accountToChange, const uint8_
         .send();
 }
 
-void daccustodian::add_all_auths(const name            &accountToChange,
+void daccustodian::add_all_auths(const name &           accountToChange,
     const vector<eosiosystem::permission_level_weight> &weights, const name &dac_id, const bool msig) {
     const auto globals = dacglobals::current(get_self(), dac_id);
 

--- a/contracts/daccustodian/privatehelpers.cpp
+++ b/contracts/daccustodian/privatehelpers.cpp
@@ -16,13 +16,14 @@ void daccustodian::updateVoteWeight(
         return; // trying to avoid throwing errors from here since it's unrelated to a transfer action.?!?!?!?!
     }
     registered_candidates.modify(candItr, same_payer, [&](auto &c) {
-        c.total_votes = S<uint64_t>{c.total_votes}.to<int64_t>() + S{weight};
+        c.total_vote_power = S<uint64_t>{c.total_vote_power}.to<int64_t>() + S{weight};
         if (from_voting) {
-            if (c.total_votes == 0) {
+            c.number_voters += weight > 0 ? 1 : -1;
+            if (c.total_vote_power == 0) {
                 c.avg_vote_time_stamp = time_point_sec(0);
             } else {
                 c.avg_vote_time_stamp =
-                    calculate_avg_vote_time_stamp(c.avg_vote_time_stamp, vote_time_stamp, weight, c.total_votes);
+                    calculate_avg_vote_time_stamp(c.avg_vote_time_stamp, vote_time_stamp, weight, c.total_vote_power);
                 check(c.avg_vote_time_stamp <= now(), "avg_vote_time_stamp pushed into the future: %s",
                     c.avg_vote_time_stamp);
             }

--- a/contracts/daccustodian/registering.cpp
+++ b/contracts/daccustodian/registering.cpp
@@ -36,11 +36,11 @@ ACTION daccustodian::nominatecane(const name &cand, const asset &requestedpay, c
         auto zero_tokens   = required_stake.quantity;
         zero_tokens.amount = 0;
         registered_candidates.emplace(cand, [&](candidate &c) {
-            c.candidate_name = cand;
-            c.requestedpay   = requestedpay;
-            c.locked_tokens  = zero_tokens;
-            c.total_votes    = 0;
-            c.is_active      = 1;
+            c.candidate_name   = cand;
+            c.requestedpay     = requestedpay;
+            c.locked_tokens    = zero_tokens;
+            c.total_vote_power = 0;
+            c.is_active        = 1;
         });
     }
 }
@@ -49,7 +49,7 @@ ACTION daccustodian::withdrawcane(const name &cand, const name &dac_id) {
     require_auth(cand);
     auto        registered_candidates = candidates_table{_self, dac_id.value};
     const auto &reg_candidate         = registered_candidates.get(
-                cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
+        cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
     check(reg_candidate.is_active, "ERR::REMOVECANDIDATE_CANDIDATE_NOT_ACTIVE::Candidate is not active.");
     disableCandidate(cand, dac_id);
 }
@@ -127,18 +127,18 @@ ACTION daccustodian::appointcust(const vector<name> &custs, const name &dac_id) 
         auto cand = candidates.find(cust.value);
         if (cand == candidates.end()) {
             candidates.emplace(auth_account, [&](candidate &c) {
-                c.candidate_name = cust;
-                c.requestedpay   = req_pay.quantity;
-                c.locked_tokens  = lockup.quantity;
-                c.total_votes    = 0;
-                c.is_active      = 1;
+                c.candidate_name   = cust;
+                c.requestedpay     = req_pay.quantity;
+                c.locked_tokens    = lockup.quantity;
+                c.total_vote_power = 0;
+                c.is_active        = 1;
             });
         }
 
         custodians.emplace(auth_account, [&](custodian &c) {
-            c.cust_name    = cust;
-            c.requestedpay = req_pay.quantity;
-            c.total_votes  = 0;
+            c.cust_name        = cust;
+            c.requestedpay     = req_pay.quantity;
+            c.total_vote_power = 0;
         });
     }
 }
@@ -187,7 +187,7 @@ void daccustodian::removeCustodian(name cust, name dac_id) {
 void daccustodian::disableCandidate(name cand, name dac_id) {
     auto        registered_candidates = candidates_table{_self, dac_id.value};
     const auto &reg_candidate         = registered_candidates.get(
-                cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
+        cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
 
     if (!reg_candidate.is_active) {
         return;
@@ -209,7 +209,7 @@ void daccustodian::disableCandidate(name cand, name dac_id) {
 void daccustodian::removeCandidate(name cand, name dac_id) {
     auto        registered_candidates = candidates_table{_self, dac_id.value};
     const auto &reg_candidate         = registered_candidates.get(
-                cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
+        cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
     check(!reg_candidate.is_active, "ERR::REMOVECANDIDATE_CANDIDATE_IS_ACTIVE::Candidate is still active.");
 
     // remove entry for candperms


### PR DESCRIPTION
This was a late design request so the vote_count could be displayed per candidate - even though it's not used in the voting logic.


Also changed `total_vote_count` to `total_vote_power` to make it less ambiguous what the field means.

This change could be done without migration by taking the old/unused `custodian_end_time_stamp` and using it for `number_voters`. This worked because the size in the table is the same (uint32).