### PR TITLE
Demzne 1097 Make candidate ranking visible

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -116,13 +116,13 @@ namespace eosdac {
     struct [[eosio::table("candidates"), eosio::contract("daccustodian")]] candidate {
         eosio::name           candidate_name;
         eosio::asset          requestedpay;
-        eosio::asset          locked_tokens;
+        uint64_t              rank;
         uint64_t              total_vote_power;
         uint8_t               is_active;
         uint32_t              number_voters;
         eosio::time_point_sec avg_vote_time_stamp;
 
-        uint64_t by_decayed_votes() const {
+        uint64_t calc_decayed_votes_index() const {
             // log(0) is -infinity, so we always add 1. This does not change the order of the index.
             const auto log_arg = S{total_vote_power} + S{1ull};
             const auto log     = log2(log_arg.to<double>());
@@ -132,6 +132,15 @@ namespace eosdac {
             const auto x_rounded_down = narrow_cast<uint64_t>(x);
             return S{UINT64_MAX} - S{x_rounded_down};
         }
+
+        uint64_t by_decayed_votes() const {
+            return rank;
+        }
+
+        void update_index() {
+            rank = calc_decayed_votes_index();
+        }
+
         uint64_t primary_key() const {
             return candidate_name.value;
         }
@@ -227,8 +236,8 @@ namespace eosdac {
     struct [[eosio::table("state2"), eosio::contract("daccustodian")]] contr_state2 {
         eosio::time_point_sec                  lastperiodtime = time_point_sec(0);
         std::map<uint8_t, state_value_variant> data           = {{state_keys::total_weight_of_votes, int64_t(0)},
-            {state_keys::total_votes_on_candidates, int64_t(0)}, {state_keys::number_active_candidates, uint32_t(0)},
-            {state_keys::met_initial_votes_threshold, false}, {state_keys::lastclaimbudgettime, time_point_sec(0)}};
+                      {state_keys::total_votes_on_candidates, int64_t(0)}, {state_keys::number_active_candidates, uint32_t(0)},
+                      {state_keys::met_initial_votes_threshold, false}, {state_keys::lastclaimbudgettime, time_point_sec(0)}};
 
         static contr_state2 get_current_state(const eosio::name account, const eosio::name scope) {
             return statecontainer2(account, scope.value).get_or_default(contr_state2{});

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -490,6 +490,7 @@ namespace eosdac {
         ACTION paycpu(const name &dac_id);
         ACTION claimbudget(const name &dac_id);
         ACTION migratestate(const name &dac_id);
+        ACTION migraterank(const name &dac_id);
         ACTION setbudget(const name &dac_id, const uint16_t percentage);
         ACTION unsetbudget(const name &dac_id);
 #ifdef DEBUG
@@ -500,6 +501,7 @@ namespace eosdac {
 #endif
 
 #ifdef IS_DEV
+        ACTION clearrank(const name &dac_id);
         ACTION fillstate(const name &dac_id);
 #endif
         /**

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -3407,6 +3407,34 @@ describe('Daccustodian', () => {
         await shared.dacdirectory_contract.indextest();
       });
     });
+    context('migraterank', async () => {
+      const dacId = 'nperidac';
+      let table_before;
+      before(async () => {
+        let res = await shared.daccustodian_contract.candidatesTable({
+          scope: dacId,
+        });
+        table_before = res.rows;
+        await shared.daccustodian_contract.clearrank(dacId);
+        res = await shared.daccustodian_contract.candidatesTable({
+          scope: dacId,
+        });
+        for (const row of res.rows) {
+          chai.expect(row.rank).to.equal(314159);
+        }
+      });
+      it('migraterank should work', async () => {
+        await shared.daccustodian_contract.migraterank(dacId);
+      });
+      it('should update rank index', async () => {
+        await assertRowsEqual(
+          shared.daccustodian_contract.candidatesTable({
+            scope: dacId,
+          }),
+          table_before
+        );
+      });
+    });
   });
 });
 

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -855,7 +855,6 @@ describe('Daccustodian', () => {
         for (const cand of currentCandidates.rows) {
           chai.expect(cand).to.include({
             is_active: 1,
-            locked_tokens: '0.0000 AVGDAC',
             total_vote_power: 0,
             number_voters: 0,
           });
@@ -909,7 +908,6 @@ describe('Daccustodian', () => {
         for (const cand of currentCandidates.rows) {
           chai.expect(cand).to.include({
             is_active: 1,
-            locked_tokens: '0.0000 CANDAC',
             total_vote_power: 0,
             number_voters: 0,
           });
@@ -935,177 +933,177 @@ describe('Daccustodian', () => {
     context('After voting', async () => {
       const num_voters = 2;
       context('with first vote', async () => {
-      before(async () => {
-        // Place votes for even number candidates and leave odd number without votes.
-        // Only vote with the first 2 members
+        before(async () => {
+          // Place votes for even number candidates and leave odd number without votes.
+          // Only vote with the first 2 members
           for (const member of regMembers.slice(0, num_voters)) {
-          await debugPromise(
-            shared.daccustodian_contract.votecust(
-              member.name,
-              [cands[0].name, cands[2].name],
-              dacId,
-              { from: member }
-            ),
-            'voting custodian'
-          );
-        }
-      });
-      it('votes table should have rows', async () => {
-        const res = await shared.daccustodian_contract.votesTable({
-          scope: dacId,
+            await debugPromise(
+              shared.daccustodian_contract.votecust(
+                member.name,
+                [cands[0].name, cands[2].name],
+                dacId,
+                { from: member }
+              ),
+              'voting custodian'
+            );
+          }
         });
-        const rows = res.rows;
-        chai
-          .expect(rows.map((x) => x.voter))
+        it('votes table should have rows', async () => {
+          const res = await shared.daccustodian_contract.votesTable({
+            scope: dacId,
+          });
+          const rows = res.rows;
+          chai
+            .expect(rows.map((x) => x.voter))
             .to.deep.equalInAnyOrder(
               regMembers.slice(0, num_voters).map((x) => x.name)
             );
 
-        chai
-          .expect(rows[0].candidates)
-          .deep.equal([cands[0].name, cands[2].name]);
-        chai.expect(rows[0].proxy).to.equal('');
-        chai.expect(rows[0].vote_count).to.equal(0);
-        expect_recent(rows[0].vote_time_stamp);
-        chai
-          .expect(rows[1].candidates)
-          .deep.equal([cands[0].name, cands[2].name]);
-        chai.expect(rows[1].proxy).to.equal('');
-        expect_recent(rows[1].vote_time_stamp);
-        chai.expect(rows[1].vote_count).to.equal(0);
-      });
-      it('only candidates with votes have total_vote_power values', async () => {
-        let unvotedCandidateResult =
-          await shared.daccustodian_contract.candidatesTable({
-            scope: dacId,
-            limit: 1,
-            lowerBound: cands[1].name,
-          });
-
-        chai
-          .expect(unvotedCandidateResult.rows[0].total_vote_power)
-          .to.equal(0);
-          chai.expect(unvotedCandidateResult.rows[0].number_voters).to.equal(0);
-        let votedCandidateResult =
-          await shared.daccustodian_contract.candidatesTable({
-            scope: dacId,
-            limit: 1,
-            lowerBound: cands[0].name,
-          });
-
-        chai.expect(votedCandidateResult.rows[0]).to.include({
-          total_vote_power: 20_000_000,
+          chai
+            .expect(rows[0].candidates)
+            .deep.equal([cands[0].name, cands[2].name]);
+          chai.expect(rows[0].proxy).to.equal('');
+          chai.expect(rows[0].vote_count).to.equal(0);
+          expect_recent(rows[0].vote_time_stamp);
+          chai
+            .expect(rows[1].candidates)
+            .deep.equal([cands[0].name, cands[2].name]);
+          chai.expect(rows[1].proxy).to.equal('');
+          expect_recent(rows[1].vote_time_stamp);
+          chai.expect(rows[1].vote_count).to.equal(0);
         });
+        it('only candidates with votes have total_vote_power values', async () => {
+          let unvotedCandidateResult =
+            await shared.daccustodian_contract.candidatesTable({
+              scope: dacId,
+              limit: 1,
+              lowerBound: cands[1].name,
+            });
+
+          chai
+            .expect(unvotedCandidateResult.rows[0].total_vote_power)
+            .to.equal(0);
+          chai.expect(unvotedCandidateResult.rows[0].number_voters).to.equal(0);
+          let votedCandidateResult =
+            await shared.daccustodian_contract.candidatesTable({
+              scope: dacId,
+              limit: 1,
+              lowerBound: cands[0].name,
+            });
+
+          chai.expect(votedCandidateResult.rows[0]).to.include({
+            total_vote_power: 20_000_000,
+          });
           chai
             .expect(votedCandidateResult.rows[0].number_voters)
             .to.equal(num_voters);
-        await assertRowCount(
-          shared.daccustodian_contract.votesTable({
-            scope: dacId,
-          }),
+          await assertRowCount(
+            shared.daccustodian_contract.votesTable({
+              scope: dacId,
+            }),
             num_voters
-        );
-      });
-      it('state should have increased the total_weight_of_votes', async () => {
-        const actual = await get_from_dacglobals(
-          dacId,
-          'total_weight_of_votes'
-        );
-        chai.expect(actual).to.equal(20_000_000);
-      });
-      it('state should have increased the total_votes_on_candidates', async () => {
-        const actual = await get_from_dacglobals(
-          dacId,
-          'total_votes_on_candidates'
-        );
-        chai.expect(actual).to.equal(20_000_000);
-      });
-    });
-    context('After same users voting again', async () => {
-      before(async () => {
-        // Place votes for even number candidates and leave odd number without votes.
-        // Only vote with the first 2 members
-          for (const member of regMembers.slice(0, num_voters)) {
-          await debugPromise(
-            shared.daccustodian_contract.votecust(
-              member.name,
-              [cands[0].name, cands[2].name],
-              dacId,
-              { from: member }
-            ),
-            'voting custodian'
           );
-        }
-      });
-      it('votes table should have rows', async () => {
-        const res = await shared.daccustodian_contract.votesTable({
-          scope: dacId,
         });
-        const rows = res.rows;
-        chai
-          .expect(rows.map((x) => x.voter))
+        it('state should have increased the total_weight_of_votes', async () => {
+          const actual = await get_from_dacglobals(
+            dacId,
+            'total_weight_of_votes'
+          );
+          chai.expect(actual).to.equal(20_000_000);
+        });
+        it('state should have increased the total_votes_on_candidates', async () => {
+          const actual = await get_from_dacglobals(
+            dacId,
+            'total_votes_on_candidates'
+          );
+          chai.expect(actual).to.equal(20_000_000);
+        });
+      });
+      context('After same users voting again', async () => {
+        before(async () => {
+          // Place votes for even number candidates and leave odd number without votes.
+          // Only vote with the first 2 members
+          for (const member of regMembers.slice(0, num_voters)) {
+            await debugPromise(
+              shared.daccustodian_contract.votecust(
+                member.name,
+                [cands[0].name, cands[2].name],
+                dacId,
+                { from: member }
+              ),
+              'voting custodian'
+            );
+          }
+        });
+        it('votes table should have rows', async () => {
+          const res = await shared.daccustodian_contract.votesTable({
+            scope: dacId,
+          });
+          const rows = res.rows;
+          chai
+            .expect(rows.map((x) => x.voter))
             .to.deep.equalInAnyOrder(
               regMembers.slice(0, num_voters).map((x) => x.name)
             );
 
-        chai
-          .expect(rows[0].candidates)
-          .deep.equal([cands[0].name, cands[2].name]);
-        chai.expect(rows[0].proxy).to.equal('');
-        chai.expect(rows[0].vote_count).to.equal(1);
-        expect_recent(rows[0].vote_time_stamp);
-        chai
-          .expect(rows[1].candidates)
-          .deep.equal([cands[0].name, cands[2].name]);
-        chai.expect(rows[1].proxy).to.equal('');
-        expect_recent(rows[1].vote_time_stamp);
+          chai
+            .expect(rows[0].candidates)
+            .deep.equal([cands[0].name, cands[2].name]);
+          chai.expect(rows[0].proxy).to.equal('');
+          chai.expect(rows[0].vote_count).to.equal(1);
+          expect_recent(rows[0].vote_time_stamp);
+          chai
+            .expect(rows[1].candidates)
+            .deep.equal([cands[0].name, cands[2].name]);
+          chai.expect(rows[1].proxy).to.equal('');
+          expect_recent(rows[1].vote_time_stamp);
 
-        chai.expect(rows[1].vote_count).to.equal(1);
-      });
-      it('only candidates with votes have total_vote_power values', async () => {
-        let unvotedCandidateResult =
-          await shared.daccustodian_contract.candidatesTable({
-            scope: dacId,
-            limit: 1,
-            lowerBound: cands[1].name,
-          });
-
-        chai
-          .expect(unvotedCandidateResult.rows[0].total_vote_power)
-          .to.equal(0);
-        let votedCandidateResult =
-          await shared.daccustodian_contract.candidatesTable({
-            scope: dacId,
-            limit: 1,
-            lowerBound: cands[0].name,
-          });
-
-        chai.expect(votedCandidateResult.rows[0]).to.include({
-          total_vote_power: 20_000_000,
-            number_voters: num_voters,
+          chai.expect(rows[1].vote_count).to.equal(1);
         });
-        await assertRowCount(
-          shared.daccustodian_contract.votesTable({
-            scope: dacId,
-          }),
+        it('only candidates with votes have total_vote_power values', async () => {
+          let unvotedCandidateResult =
+            await shared.daccustodian_contract.candidatesTable({
+              scope: dacId,
+              limit: 1,
+              lowerBound: cands[1].name,
+            });
+
+          chai
+            .expect(unvotedCandidateResult.rows[0].total_vote_power)
+            .to.equal(0);
+          let votedCandidateResult =
+            await shared.daccustodian_contract.candidatesTable({
+              scope: dacId,
+              limit: 1,
+              lowerBound: cands[0].name,
+            });
+
+          chai.expect(votedCandidateResult.rows[0]).to.include({
+            total_vote_power: 20_000_000,
+            number_voters: num_voters,
+          });
+          await assertRowCount(
+            shared.daccustodian_contract.votesTable({
+              scope: dacId,
+            }),
             num_voters
-        );
+          );
+        });
+        it('state should not have increased the total_weight_of_votes', async () => {
+          const actual = await get_from_dacglobals(
+            dacId,
+            'total_weight_of_votes'
+          );
+          chai.expect(actual).to.equal(20_000_000);
+        });
+        it('state should not have increased the total_votes_on_candidates', async () => {
+          const actual = await get_from_dacglobals(
+            dacId,
+            'total_votes_on_candidates'
+          );
+          chai.expect(actual).to.equal(20_000_000);
+        });
       });
-      it('state should not have increased the total_weight_of_votes', async () => {
-        const actual = await get_from_dacglobals(
-          dacId,
-          'total_weight_of_votes'
-        );
-        chai.expect(actual).to.equal(20_000_000);
-      });
-      it('state should not have increased the total_votes_on_candidates', async () => {
-        const actual = await get_from_dacglobals(
-          dacId,
-          'total_votes_on_candidates'
-        );
-        chai.expect(actual).to.equal(20_000_000);
-      });
-    });
     });
     context('After additional voting, then removing votes', async () => {
       let newVoter: Account;
@@ -2932,7 +2930,6 @@ describe('Daccustodian', () => {
       chai.expect(candidates.rows.length).equals(5);
 
       chai.expect(candidates.rows[0].requestedpay).to.equal('0.0000 EOS');
-      chai.expect(candidates.rows[0].locked_tokens).to.equal('0.0000 APPDAC');
       chai.expect(candidates.rows[0].total_vote_power).to.equal(0);
       chai.expect(candidates.rows[0].number_voters).to.equal(0);
       chai.expect(candidates.rows[0].is_active).to.equal(1);

--- a/contracts/daccustodian/debug.cpp
+++ b/contracts/daccustodian/debug.cpp
@@ -32,6 +32,7 @@ void daccustodian::resetcands(const name &dac_id) {
             c.total_vote_power    = 0;
             c.number_voters       = 0;
             c.avg_vote_time_stamp = eosio::time_point_sec();
+            c.update_index();
         });
 
         cand++;

--- a/contracts/daccustodian/privatehelpers.cpp
+++ b/contracts/daccustodian/privatehelpers.cpp
@@ -32,6 +32,7 @@ void daccustodian::updateVoteWeight(
                     c.avg_vote_time_stamp);
             }
         }
+        c.update_index();
     });
 }
 

--- a/contracts/daccustodian/registering.cpp
+++ b/contracts/daccustodian/registering.cpp
@@ -30,8 +30,6 @@ ACTION daccustodian::nominatecane(const name &cand, const asset &requestedpay, c
             c.requestedpay = requestedpay;
         });
     } else {
-        extended_asset required_stake = globals.get_lockupasset();
-
         registered_candidates.emplace(cand, [&](candidate &c) {
             c.candidate_name   = cand;
             c.requestedpay     = requestedpay;

--- a/contracts/daccustodian/registering.cpp
+++ b/contracts/daccustodian/registering.cpp
@@ -32,15 +32,12 @@ ACTION daccustodian::nominatecane(const name &cand, const asset &requestedpay, c
     } else {
         extended_asset required_stake = globals.get_lockupasset();
 
-        // locked_tokens is now ignored, staking is done in the token contract
-        auto zero_tokens   = required_stake.quantity;
-        zero_tokens.amount = 0;
         registered_candidates.emplace(cand, [&](candidate &c) {
             c.candidate_name   = cand;
             c.requestedpay     = requestedpay;
-            c.locked_tokens    = zero_tokens;
             c.total_vote_power = 0;
             c.is_active        = 1;
+            c.update_index();
         });
     }
 }
@@ -49,7 +46,7 @@ ACTION daccustodian::withdrawcane(const name &cand, const name &dac_id) {
     require_auth(cand);
     auto        registered_candidates = candidates_table{_self, dac_id.value};
     const auto &reg_candidate         = registered_candidates.get(
-        cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
+                cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
     check(reg_candidate.is_active, "ERR::REMOVECANDIDATE_CANDIDATE_NOT_ACTIVE::Candidate is not active.");
     disableCandidate(cand, dac_id);
 }
@@ -129,9 +126,9 @@ ACTION daccustodian::appointcust(const vector<name> &custs, const name &dac_id) 
             candidates.emplace(auth_account, [&](candidate &c) {
                 c.candidate_name   = cust;
                 c.requestedpay     = req_pay.quantity;
-                c.locked_tokens    = lockup.quantity;
                 c.total_vote_power = 0;
                 c.is_active        = 1;
+                c.update_index();
             });
         }
 
@@ -187,7 +184,7 @@ void daccustodian::removeCustodian(name cust, name dac_id) {
 void daccustodian::disableCandidate(name cand, name dac_id) {
     auto        registered_candidates = candidates_table{_self, dac_id.value};
     const auto &reg_candidate         = registered_candidates.get(
-        cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
+                cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
 
     if (!reg_candidate.is_active) {
         return;
@@ -209,7 +206,7 @@ void daccustodian::disableCandidate(name cand, name dac_id) {
 void daccustodian::removeCandidate(name cand, name dac_id) {
     auto        registered_candidates = candidates_table{_self, dac_id.value};
     const auto &reg_candidate         = registered_candidates.get(
-        cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
+                cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
     check(!reg_candidate.is_active, "ERR::REMOVECANDIDATE_CANDIDATE_IS_ACTIVE::Candidate is still active.");
 
     // remove entry for candperms

--- a/contracts/daccustodian/voting.cpp
+++ b/contracts/daccustodian/voting.cpp
@@ -155,3 +155,26 @@ ACTION daccustodian::voteproxy(const name &voter, const name &proxyName, const n
 
     modifyProxiesWeight(vote_weight, oldProxy, newProxy, dac_id, true);
 }
+
+#ifdef IS_DEV
+// Used for testing migraterank
+void daccustodian::clearrank(const name &dac_id) {
+
+    auto candidates = candidates_table{get_self(), dac_id.value};
+    for (auto &candidate : candidates) {
+        candidates.modify(candidate, same_payer, [&](auto &c) {
+            c.rank = 314159;
+        });
+    }
+}
+#endif
+
+// Needs to be called for every dac after deployment to fill the index (rank field)
+void daccustodian::migraterank(const name &dac_id) {
+    auto candidates = candidates_table{get_self(), dac_id.value};
+    for (auto &candidate : candidates) {
+        candidates.modify(candidate, same_payer, [&](auto &c) {
+            c.update_index();
+        });
+    }
+}


### PR DESCRIPTION
* Recycles the currently unused member `locked_tokens` of the `candidate` struct to store the `by_decayed_votes` index in a publicly visible field
* It manually call update_index where necessary. Not an ideal solution but eosio::multi_index has no way to update dependant fields or to register pre-save functions. Eosio-cpp also has c#-style properties disabled, so that can't be used either for a more elegant solution.

After deployment, the `migraterank` action needs to be called for every dac.