### PR TITLE
Adds minimal smart contract to be used for DAO activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ node_modules
 /contracts/atomicassets/atomicassets.ts
 /artifacts/compiled_contracts/contracts/safemath
 /contracts/safemath/safemath.ts
+artifacts/compiled_contracts

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -259,7 +259,7 @@ ACTION daccustodian::newperiod(const string &message, const name &dac_id) {
 
     if (activation_account) {
         require_auth(*activation_account);
-        auths.emplace_back(*activation_account, "owner"_n);
+        auths.emplace_back(*activation_account, "active"_n);
     }
 
     eosio::action(auths, get_self(), "runnewperiod"_n, make_tuple(message, dac_id)).send();

--- a/contracts/newperiodctl/newperiodctl.cpp
+++ b/contracts/newperiodctl/newperiodctl.cpp
@@ -1,0 +1,16 @@
+#include <eosio/eosio.hpp>
+
+using namespace eosio;
+
+namespace alienworlds {
+
+    CONTRACT newperiodctl : public contract {
+      public:
+        newperiodctl(name self, name code, datastream<const char *> ds) : contract(self, code, ds) {}
+
+        ACTION assertunlock(const name dac_id) {
+            require_auth(get_self());
+        };
+    };
+
+} // namespace alienworlds

--- a/contracts/newperiodctl/newperiodctl.ts
+++ b/contracts/newperiodctl/newperiodctl.ts
@@ -1,0 +1,26 @@
+// =====================================================
+// WARNING: GENERATED FILE
+//
+// Any changes you make will be overwritten by Lamington
+// =====================================================
+
+import { Account, Contract, GetTableRowsOptions, ExtendedAsset, ExtendedSymbol, ActorPermission } from 'lamington';
+
+// Table row types
+export interface NewperiodctlAssertunlock {
+	dac_id: string|number;
+}
+
+// Added Types
+
+// Variants
+
+export interface Newperiodctl extends Contract {
+	// Actions
+	assertunlock(dac_id: string|number, options?: { from?: Account, auths?: ActorPermission[] }): Promise<any>;
+	// Actions with object params. (This is WIP and not ready for use)
+	assertunlock_object_params(params: {dac_id: string|number}, options?: { from?: Account, auths?: ActorPermission[] }): Promise<any>;
+	
+	// Tables
+}
+


### PR DESCRIPTION
Also changes the permission used from owner to active for better permission management.

Please check the git ignore. I changed it to ignore all files in the compiled contract rather each individual contract. Not sure if there was a reason not to do that earlier. So let me know if this should be reverted.