### PR TITLE
Adding conditional checks to to lock config focus actions

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -501,7 +501,6 @@ namespace eosdac {
         ACTION resetcands(const name &dac_id);
         ACTION resetstate(const name &dac_id);
         ACTION clearcands(const name &dac_id);
-        ACTION erasecand(const name &cand, const name &dac_id);
 #endif
 
 #ifdef IS_DEV

--- a/contracts/daccustodian/config.cpp
+++ b/contracts/daccustodian/config.cpp
@@ -4,8 +4,13 @@ using namespace eosdac;
 ACTION daccustodian::updateconfige(const contr_config &new_config, const name &dac_id) {
 
     dacdir::dac dacForScope = dacdir::dac_for_id(dac_id);
-    auto        owner       = dacForScope.owner;
-    require_auth(owner);
+#ifdef IS_DEV
+    // This will be enabled later in prod instead of get_self() to allow DAO's to control this config.
+    require_auth(dacForScope.owner);
+#else
+    require_auth(get_self());
+#endif
+
     check(new_config.numelected <= 67,
         "ERR::UPDATECONFIG_INVALID_NUM_ELECTED::The number of elected custodians must be <= 67");
     check(new_config.maxvotes <= new_config.numelected,

--- a/contracts/daccustodian/debug.cpp
+++ b/contracts/daccustodian/debug.cpp
@@ -49,14 +49,3 @@ void daccustodian::clearcands(const name &dac_id) {
         cand = candidates.erase(cand);
     }
 }
-
-void daccustodian::erasecand(const name &cand, const name &dac_id) {
-    require_auth(get_self());
-
-    candidates_table candidates(_self, dac_id.value);
-    auto             existingCand = candidates.find(cand.value);
-
-    check(existingCand != candidates.end(), "No candidate");
-
-    candidates.erase(existingCand);
-}

--- a/contracts/daccustodian/update_member_details.cpp
+++ b/contracts/daccustodian/update_member_details.cpp
@@ -12,7 +12,7 @@ ACTION daccustodian::updatebio(const name &cand, const string &bio, const name &
 
 ACTION daccustodian::flagcandprof(
     const name &cand, const std::string &reason, const name &reporter, const bool block, const name &dac_id) {
-    static auto flag_reporters = vector<eosio::name>{"ameet.worlds"_n, "anya.worlds"_n};
+    static auto flag_reporters = vector<eosio::name>{"ameet.worlds"_n, "aliensupport"_n};
     require_auth(reporter);
     check(std::find(flag_reporters.begin(), flag_reporters.end(), reporter) != flag_reporters.end(),
         "Not Authorised to flag or unflag candates");

--- a/contracts/eosdactokens/eosdactokens.hpp
+++ b/contracts/eosdactokens/eosdactokens.hpp
@@ -32,11 +32,13 @@ namespace eosdac {
         ACTION newmemterms(string terms, string hash, name dac_id);
         ACTION memberreg(name sender, string agreedterms, name dac_id);
         ACTION memberunreg(name sender, name dac_id);
-        ACTION updateterms(uint64_t termsid, string terms, name dac_id);
+        // When using IPFS this action doesn't make sense any more. Commenting out for now.
+        // ACTION updateterms(uint64_t termsid, string terms, name dac_id);
         ACTION close(name owner, const symbol &symbol);
 
         // staking
-        ACTION xferstake(name from, name to, asset quantity, string memo);
+        // Disabling xfer of stake at least for the initial release. Not sure why it was ever added.
+        // ACTION xferstake(name from, name to, asset quantity, string memo);
         ACTION stake(name account, asset quantity);
         ACTION unstake(name account, asset quantity);
         ACTION staketime(name account, uint32_t unstake_time, symbol token_symbol);

--- a/contracts/stakevote/stakevote.cpp
+++ b/contracts/stakevote/stakevote.cpp
@@ -70,16 +70,20 @@ void stakevote::balanceobsv(const vector<account_balance_delta> &balance_deltas,
 }
 
 void stakevote::updateconfig(config_item &new_config, const name dac_id) {
-    const auto dac          = dacdir::dac_for_id(dac_id);
-    const auto auth_account = dac.owner;
-    require_auth(auth_account);
+    const auto dac = dacdir::dac_for_id(dac_id);
+#ifdef IS_DEV
+    // This will be enabled later in prod instead of get_self() to allow DAO's to control this config.
+    require_auth(dac.owner);
+#else
+    require_auth(get_self());
+#endif
     check(new_config.time_multiplier > 0, "time_multiplier must be greater than zero");
 
     new_config.save(get_self(), dac_id, get_self());
 }
 
-// Only needed temporarily for dev/testing and migration of the current planets to stake weighted voting
-// Start - - - - -v
+#ifdef DEBUG
+
 void stakevote::clearweights(uint16_t batch_size, name dac_id) {
     require_auth(get_self());
     weight_table weights(get_self(), dac_id.value);
@@ -133,4 +137,4 @@ void stakevote::collectwts(uint16_t batch_size, uint32_t unstake_time, name dac_
         counter++;
     }
 }
-// End - - - - -^
+#endif

--- a/contracts/stakevote/stakevote.hpp
+++ b/contracts/stakevote/stakevote.hpp
@@ -43,8 +43,10 @@ CONTRACT stakevote : public contract {
     ACTION balanceobsv(const vector<account_balance_delta> &balance_deltas, const name dac_id);
     ACTION updateconfig(config_item & new_config, const name dac_id);
 
+#ifdef DEBUG
     ACTION clearweights(uint16_t batch_size, name dac_id);
     ACTION collectwts(uint16_t batch_size, uint32_t unstake_time, name dac_id);
+#endif
 
     struct [[eosio::table("stakes"), eosio::contract("eosdactokens")]] stake_info {
         name  account;


### PR DESCRIPTION
These should only be callable by get_self() with the long-term intention to open these up for the DAO to call later.

In an attempt to not break all the unit tests these changes have been wrapped with `#if IS_DEV` 
I don't think these changes need unit tests to verify. I will manually test on-chain before the DAOs go live.

Also removed a couple of actions from the token contract which will create more confusion than value.

@angelol Sorry, I haven't run the unit tests on this change to be sure I haven't broken anything. But potentially something may have broken - particularly since I removed actions that may have had tests.