### PR TITLE
Demzne 1102 eosdac lockdown of contract config actions - boundary case checks

### DIFF
--- a/contracts/eosdactokens/eosdactokens.cpp
+++ b/contracts/eosdactokens/eosdactokens.cpp
@@ -209,7 +209,6 @@ namespace eosdac {
     }
 
     void eosdactokens::memberreg(name sender, string agreedterms, name dac_id) {
-        // agreedterms is expected to be the member terms document hash
         require_auth(sender);
 
         memterms memberterms(_self, dac_id.value);
@@ -233,27 +232,6 @@ namespace eosdac {
             });
         }
     }
-
-    // void eosdactokens::updateterms(uint64_t termsid, string terms, name dac_id) {
-
-    //     dacdir::dac dac          = dacdir::dac_for_id(dac_id);
-    //     eosio::name auth_account = dac.owner;
-    //     require_auth(auth_account);
-
-    //     check(terms.length() <= 256,
-    //         "ERR::UPDATEMEMTERMS_TERMS_TOO_LONG::Member terms document url should be less than 256 characters
-    //         long.");
-
-    //     memterms memberterms(_self, dac_id.value);
-
-    //     auto existingterms = memberterms.find(termsid);
-    //     check(existingterms != memberterms.end(),
-    //         "ERR::UPDATETERMS_NO_EXISTING_TERMS::Existing terms not found for the given ID");
-
-    //     memberterms.modify(existingterms, same_payer, [&](termsinfo &t) {
-    //         t.terms = terms;
-    //     });
-    // }
 
     void eosdactokens::memberunreg(name sender, name dac_id) {
         require_auth(sender);
@@ -433,6 +411,13 @@ namespace eosdac {
 #else
         require_auth(get_self());
 #endif
+
+        auto existing_config = stake_config::get_current_configs(get_self(), dac.dac_id);
+        check(config.max_stake_time >= existing_config.max_stake_time,
+            "ERR::CONFIG_MAX_TIME_LT_EXISTING_MAX::Max Unstake time cannot bre reduced.");
+        check(config.min_stake_time < config.max_stake_time,
+            "ERR::CONFIG_MIN_TIME_NOT_LT_MAX::Min unstake time must be less than the max unstake time.");
+
         config.save(get_self(), dac.dac_id, get_self());
     }
 

--- a/contracts/eosdactokens/eosdactokens.hpp
+++ b/contracts/eosdactokens/eosdactokens.hpp
@@ -32,8 +32,6 @@ namespace eosdac {
         ACTION newmemterms(string terms, string hash, name dac_id);
         ACTION memberreg(name sender, string agreedterms, name dac_id);
         ACTION memberunreg(name sender, name dac_id);
-        // When using IPFS this action doesn't make sense any more. Commenting out for now.
-        // ACTION updateterms(uint64_t termsid, string terms, name dac_id);
         ACTION close(name owner, const symbol &symbol);
 
         // staking

--- a/contracts/stakevote/stakevote.cpp
+++ b/contracts/stakevote/stakevote.cpp
@@ -77,7 +77,11 @@ void stakevote::updateconfig(config_item &new_config, const name dac_id) {
 #else
     require_auth(get_self());
 #endif
-    check(new_config.time_multiplier > 0, "time_multiplier must be greater than zero");
+    check(new_config.time_multiplier > 0, "ERR::STAKE_MULTI_NOT_GT_ZERO::time_multiplier must be greater than zero");
+    const auto existing_config = config_item::get_current_configs(get_self(), dac_id);
+
+    check(new_config.time_multiplier > existing_config.time_multiplier,
+        "ERR::STAKE_MULTI_NOT_INCREASED::new time_multiplier must be greater than the existing configuration.");
 
     new_config.save(get_self(), dac_id, get_self());
 }


### PR DESCRIPTION
Adds simple checks to ensure that config settings will not break existing user data logic.