### PR TITLE
Reverse the index of the candidate decayed votes value.

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -131,7 +131,7 @@ namespace eosdac {
                 S{log} + S{avg_vote_time_stamp.sec_since_epoch()}.to<double>() / S{SECONDS_TO_DOUBLE}.to<double>();
             check(x >= double{}, "by_decayed_votes x must be >= 0 before uint64_t conversion");
             const auto x_rounded_down = narrow_cast<uint64_t>(x);
-            return S{UINT64_MAX} - S{x_rounded_down};
+            return x_rounded_down;
         }
 
         uint64_t by_decayed_votes() const {

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -72,7 +72,7 @@ void daccustodian::allocateCustodians(bool early_election, name dac_id) {
     name             auth_account = dacdir::dac_for_id(dac_id).owner;
     auto             byvotes      = registered_candidates.get_index<"bydecayed"_n>();
 
-    auto cand_itr = byvotes.begin();
+    auto cand_itr = byvotes.rbegin();
 
     int32_t electcount            = globals.get_numelected();
     uint8_t currentCustodianCount = 0;
@@ -96,7 +96,7 @@ void daccustodian::allocateCustodians(bool early_election, name dac_id) {
     }
 
     while (currentCustodianCount < electcount) {
-        check(cand_itr != byvotes.end() && cand_itr->total_vote_power > 0,
+        check(cand_itr != byvotes.rend() && cand_itr->total_vote_power > 0,
             "ERR::NEWPERIOD_NOT_ENOUGH_CANDIDATES::There are not enough eligible candidates to run new period without causing potential lock out permission structures for this DAC.");
 
         //  If the candidate is inactive or is already a custodian skip to the next one.


### PR DESCRIPTION
Then Use the index in the rank field. so the value goes up instead of down.

Tried running the tests for this change but I was getting errors around the `fillstate` in daccustodian which felt like it's unrelated.

This change would be a nice-to-have if it's a low risk.

Note: I haven't used `begin()` and `rend()` before and wasn't 100% sure about it's use - particularly not 100% sure if the iterator should be `itr++` or `itr--` to step through the collection in reverse.