### PR TITLE
Demzne 1105 eosdac staking not working with current unstakes

### DIFF
--- a/contracts/eosdactokens/eosdactokens.cpp
+++ b/contracts/eosdactokens/eosdactokens.cpp
@@ -304,11 +304,10 @@ namespace eosdac {
         check(quantity.is_valid(), "ERR::STAKE_INVALID_QTY::Invalid quantity supplied");
         check(quantity.amount > 0, "ERR::STAKE_NON_POSITIVE_QTY::Stake amount must be greater than 0");
 
-        auto [liquid, debug_output] = eosdac::get_liquid_debug(account, get_self(), quantity.symbol);
+        auto liquid = eosdac::get_liquid(account, get_self(), quantity.symbol);
 
-        check(liquid >= quantity,
-            "ERR::STAKE_MORE_LIQUID::Attempting to stake %s but your liquid balance is only %s | %s", quantity, liquid,
-            debug_output);
+        check(liquid >= quantity, "ERR::STAKE_MORE_LIQUID::Attempting to stake %s but your liquid balance is only %s",
+            quantity, liquid);
 
         add_stake(account, quantity, dac.dac_id, account);
 


### PR DESCRIPTION
A common misconception (you could also call it a bug) in the way eosio::multi_index works is that contrary to primary indexes, secondary indexes don't filter out non-matching results when using find(). They only point the iterator to the first matching element. It is up to the user of the API to break the iteration once results no longer match the search criteria.