### PR TITLE
General cleanup in Prod for dao.worlds

### DIFF
--- a/contract-shared-headers/config.hpp
+++ b/contract-shared-headers/config.hpp
@@ -2,6 +2,10 @@
 
 static constexpr eosio::symbol TLM_SYM{"TLM", 4};
 #define TLM_TOKEN_CONTRACT_STR "alien.worlds"
+#define ZERO_TRILIUM                                                                                                   \
+    asset {                                                                                                            \
+        0, TLM_SYM                                                                                                     \
+    }
 static constexpr eosio::name TLM_TOKEN_CONTRACT{TLM_TOKEN_CONTRACT_STR};
 static constexpr eosio::name MSIG_CONTRACT{"msig.worlds"};
 

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -465,6 +465,7 @@ namespace eosdac {
         ACTION weightobsv(const vector<account_weight_delta> &account_weight_deltas, const name &dac_id);
 
         ACTION nominatecane(const name &cand, const eosio::asset &requestedpay, const name &dac_id);
+        ACTION nominate(const name &cand, const name &dac_id);
         ACTION withdrawcane(const name &cand, const name &dac_id);
         ACTION removecand(const name &cand, const name &dac_id);
         ACTION firecand(const name &cand, const bool lockupStake, const name &dac_id);
@@ -477,13 +478,12 @@ namespace eosdac {
 
         [[eosio::action]] inline void stprofile(const name &cand, const std::string &profile, const name &dac_id) {
             require_auth(cand);
+            check(profile.size() < 16256, "profile exceeds max size.");
         };
 
-        [[eosio::action]] inline void stprofileuns(const name &cand, const std::string &profile) {
-            require_auth(cand);
-        };
         ACTION updatereqpay(const name &cand, const eosio::asset &requestedpay, const name &dac_id);
         ACTION votecust(const name &voter, const std::vector<name> &newvotes, const name &dac_id);
+        ACTION removecstvte(const name &voter, const name &dac_id);
         ACTION voteproxy(const name &voter, const name &proxy, const name &dac_id);
         ACTION regproxy(const name &proxy, const name &dac_id);
         ACTION unregproxy(const name &proxy, const name &dac_id);

--- a/contracts/daccustodian/config.cpp
+++ b/contracts/daccustodian/config.cpp
@@ -64,3 +64,19 @@ ACTION daccustodian::updateconfige(const contr_config &new_config, const name &d
     globals.save(get_self(), dac_id);
     print("Succesfully updated the daccustodian config for: ", dac_id);
 }
+
+ACTION daccustodian::setbudget(const name &dac_id, const uint16_t percentage) {
+    require_auth(get_self());
+
+    auto globals = dacglobals::current(get_self(), dac_id);
+    globals.set_budget_percentage(percentage);
+    globals.save(get_self(), dac_id);
+}
+
+ACTION daccustodian::unsetbudget(const name &dac_id) {
+    require_auth(get_self());
+
+    auto globals = dacglobals::current(get_self(), dac_id);
+    globals.unset_budget_percentage();
+    globals.save(get_self(), dac_id);
+}

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -176,22 +176,6 @@ asset balance_for_type(const dacdir::dac &dac, const dacdir::account_type type) 
     return eosdac::get_balance_graceful(account, TLM_TOKEN_CONTRACT, TLM_SYM);
 }
 
-ACTION daccustodian::setbudget(const name &dac_id, const uint16_t percentage) {
-    require_auth(get_self());
-
-    auto globals = dacglobals::current(get_self(), dac_id);
-    globals.set_budget_percentage(percentage);
-    globals.save(get_self(), dac_id);
-}
-
-ACTION daccustodian::unsetbudget(const name &dac_id) {
-    require_auth(get_self());
-
-    auto globals = dacglobals::current(get_self(), dac_id);
-    globals.unset_budget_percentage();
-    globals.save(get_self(), dac_id);
-}
-
 ACTION daccustodian::claimbudget(const name &dac_id) {
     const auto dac          = dacdir::dac_for_id(dac_id);
     const auto auth_account = dac.owner;

--- a/contracts/daccustodian/registering.cpp
+++ b/contracts/daccustodian/registering.cpp
@@ -40,11 +40,15 @@ ACTION daccustodian::nominatecane(const name &cand, const asset &requestedpay, c
     }
 }
 
+ACTION daccustodian::nominate(const name &cand, const name &dac_id) {
+    nominatecane(cand, ZERO_TRILIUM, dac_id);
+}
+
 ACTION daccustodian::withdrawcane(const name &cand, const name &dac_id) {
     require_auth(cand);
     auto        registered_candidates = candidates_table{_self, dac_id.value};
     const auto &reg_candidate         = registered_candidates.get(
-                cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
+        cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
     check(reg_candidate.is_active, "ERR::REMOVECANDIDATE_CANDIDATE_NOT_ACTIVE::Candidate is not active.");
     disableCandidate(cand, dac_id);
 }
@@ -104,6 +108,8 @@ ACTION daccustodian::setperm(const name &cand, const name &permission, const nam
 }
 
 ACTION daccustodian::appointcust(const vector<name> &custs, const name &dac_id) {
+    check(false, "Custodians can only be appointed via elections.");
+
     dacdir::dac dac          = dacdir::dac_for_id(dac_id);
     name        auth_account = dac.owner;
     require_auth(auth_account);
@@ -182,7 +188,7 @@ void daccustodian::removeCustodian(name cust, name dac_id) {
 void daccustodian::disableCandidate(name cand, name dac_id) {
     auto        registered_candidates = candidates_table{_self, dac_id.value};
     const auto &reg_candidate         = registered_candidates.get(
-                cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
+        cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
 
     if (!reg_candidate.is_active) {
         return;
@@ -204,7 +210,7 @@ void daccustodian::disableCandidate(name cand, name dac_id) {
 void daccustodian::removeCandidate(name cand, name dac_id) {
     auto        registered_candidates = candidates_table{_self, dac_id.value};
     const auto &reg_candidate         = registered_candidates.get(
-                cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
+        cand.value, "ERR::REMOVECANDIDATE_NOT_CURRENT_CANDIDATE::Candidate is not already registered.");
     check(!reg_candidate.is_active, "ERR::REMOVECANDIDATE_CANDIDATE_IS_ACTIVE::Candidate is still active.");
 
     // remove entry for candperms
@@ -218,6 +224,7 @@ void daccustodian::removeCandidate(name cand, name dac_id) {
 }
 
 ACTION daccustodian::regproxy(const name &proxy_member, const name &dac_id) {
+    check(false, "proxy voting not yet enabled.");
     require_auth(proxy_member);
     assertValidMember(proxy_member, dac_id);
 

--- a/contracts/daccustodian/voting.cpp
+++ b/contracts/daccustodian/voting.cpp
@@ -2,7 +2,7 @@ using namespace eosdac;
 
 ACTION daccustodian::votecust(const name &voter, const vector<name> &newvotes, const name &dac_id) {
 #ifndef IS_DEV
-    check(dac_id == "testa"_n || dac_id == "testb"_n, "Voting is not yet enabled in the Planet DAOs.");
+    // check(dac_id == "testa"_n || dac_id == "testb"_n, "Voting is not yet enabled in the Planet DAOs.");
 #endif
     candidates_table registered_candidates(_self, dac_id.value);
     const auto       globals = dacglobals::current(get_self(), dac_id);
@@ -58,6 +58,10 @@ ACTION daccustodian::votecust(const name &voter, const vector<name> &newvotes, c
             v.vote_count      = 0;
         });
     }
+}
+
+ACTION daccustodian::removecstvte(const name &voter, const name &dac_id) {
+    votecust(voter, {}, dac_id);
 }
 
 void daccustodian::update_number_of_votes(
@@ -120,6 +124,7 @@ void daccustodian::modifyProxiesWeight(
 }
 
 ACTION daccustodian::voteproxy(const name &voter, const name &proxyName, const name &dac_id) {
+    check(false, "proxy voting not yet enabled.");
 
     require_auth(voter);
     assertValidMember(voter, dac_id);


### PR DESCRIPTION
* Blocks all proxy voting activity for now
* Adds convenience action to remove votes and nominate without pay.
* Removes unused stprofileuns action
* Sets a max limit on the size of the profile (Just an arbitrary number but this was completely open for now otherwise)
* Enables voting for all planets.
* Moves the budget configs with the other config actions.