### PR TITLE
Dev 2659 bug unstake vp doesnt works properly

### DIFF
--- a/contracts/TestHelpers.ts
+++ b/contracts/TestHelpers.ts
@@ -94,7 +94,7 @@ export class SharedTestObjects {
       'created daccustodian'
     );
     this.dac_token_contract = await debugPromise(
-      ContractDeployer.deployWithName('eosdactokens', 'eosdactokens'),
+      ContractDeployer.deployWithName('eosdactokens', 'token.worlds'),
       'created eosdactokens'
     );
     this.dacproposals_contract = await debugPromise(
@@ -564,7 +564,7 @@ export class SharedTestObjects {
     await UpdateAuth.execLinkAuth(
       this.treasury_account.active,
       this.treasury_account.name,
-      'eosdactokens',
+      this.dac_token_contract.account.name,
       'transfer',
       'xfer'
     );

--- a/contracts/stakevote/stakevote.cpp
+++ b/contracts/stakevote/stakevote.cpp
@@ -34,7 +34,17 @@ void stakevote::stakeobsv(const vector<account_stake_delta> &stake_deltas, const
         const auto vw_itr = weights.find(asd.account.value);
         if (vw_itr != weights.end()) {
             weights.modify(vw_itr, same_payer, [&](auto &v) {
-                v.weight        = S<uint64_t>{v.weight}.add_signed_to_unsigned(weight_delta);
+                if (weight_delta < 0.0) {
+                    check(weight_delta.abs().to<int64_t>() <= S<uint64_t>{v.weight}.to<int64_t>(),
+                        "ERR:INVALID_WEIGHT_DELTA_UPDATE: %s Trying to subtract weight_delta of %s from v.weight of %s stake_delta: %s unstake_delay: %s time_multiplier: %s max_stake_time: %s",
+                        v.voter, weight_delta.abs().to<int64_t>(), v.weight);
+                }
+                v.weight = S<uint64_t>{v.weight}.add_signed_to_unsigned(weight_delta);
+                if (weight_delta_quorum < int64_t{0}) {
+                    check(weight_delta_quorum.abs().to<int64_t>() <= S<uint64_t>{v.weight_quorum}.to<int64_t>(),
+                        "ERR:INVALID_WEIGHT_DELTA_QUORUM_UPDATE: %s Trying to subtract weight_delta_quorum %s from %s",
+                        v.voter, weight_delta_quorum, v.weight_quorum);
+                }
                 v.weight_quorum = S<uint64_t>{v.weight_quorum}.add_signed_to_unsigned(weight_delta_quorum);
             });
             if (vw_itr->weight == 0) {

--- a/contracts/stakevote/stakevote.cpp
+++ b/contracts/stakevote/stakevote.cpp
@@ -101,35 +101,40 @@ void stakevote::clearweights(uint16_t batch_size, name dac_id) {
     }
 }
 
-void stakevote::collectwts(uint16_t batch_size, name dac_id) {
+void stakevote::collectwts(uint16_t batch_size, name dac_id, bool assert) {
     require_auth(get_self());
-    auto       weights         = weight_table{get_self(), dac_id.value};
-    const auto stakes          = stakes_table{"token.worlds"_n, dac_id.value};
-    const auto config          = config_item::get_current_configs(get_self(), dac_id);
-    const auto dac             = dacdir::dac_for_id(dac_id);
-    const auto token_contract  = dac.symbol.get_contract();
-    const auto token_config    = stake_config::get_current_configs(token_contract, dac_id);
-    const auto max_stake_time  = S{token_config.max_stake_time}.to<double>();
-    const auto min_stake_time  = S{token_config.min_stake_time}.to<double>();
+    auto       weights        = weight_table{get_self(), dac_id.value};
+    const auto stakes         = stakes_table{"token.worlds"_n, dac_id.value};
+    const auto config         = config_item::get_current_configs(get_self(), dac_id);
+    const auto dac            = dacdir::dac_for_id(dac_id);
+    const auto token_contract = dac.symbol.get_contract();
+    const auto token_config   = stake_config::get_current_configs(token_contract, dac_id);
+    const auto max_stake_time = S{token_config.max_stake_time}.to<double>();
+    // const auto min_stake_time  = S{token_config.min_stake_time}.to<double>();
     const auto time_multiplier = S{config.time_multiplier}.to<double>();
 
     auto lastWeight = weights.end();
     if (lastWeight != weights.begin()) {
         lastWeight--;
     }
-    check(stakes.begin() != stakes.end(), "No stakes found.");
+    check(stakes.begin() != stakes.end(), "No stakes found for dac %s.", dac_id);
 
     auto stake   = lastWeight != weights.end() ? stakes.find((lastWeight->voter).value) : stakes.begin();
     auto counter = 0;
     while (stake != stakes.end() && counter < batch_size) {
+        const auto unstake_delay = S{staketime_info::get_delay("token.worlds"_n, dac_id, stake->account)}.to<double>();
+
         const auto vw_itr              = weights.find((stake->account).value);
         const auto weight_delta_quorum = S{(stake->stake).amount}.to<uint64_t>();
 
-        const auto stake_delta  = S{(stake->stake).amount}.to<double>();
-        const auto weight_delta = stake_delta * (S{1.0} + min_stake_time * time_multiplier / max_stake_time);
-        const auto weight_delta = weight_delta_s.to<uint64_t>();
+        const auto stake_delta    = S{(stake->stake).amount}.to<double>();
+        const auto weight_delta_s = stake_delta * (S{1.0} + unstake_delay * time_multiplier / max_stake_time);
+        const auto weight_delta   = weight_delta_s.to<uint64_t>();
 
         if (vw_itr == weights.end()) {
+            if (assert) {
+                ::check(false, "Voter %s has no vote_weight but should be '%s' ", weight_delta);
+            }
             weights.emplace(get_self(), [&](auto &v) {
                 v.voter         = stake->account;
                 v.weight        = weight_delta;
@@ -137,6 +142,11 @@ void stakevote::collectwts(uint16_t batch_size, name dac_id) {
             });
         } else {
             weights.modify(vw_itr, same_payer, [&](auto &v) {
+                if (assert) {
+                    check(v.weight == weight_delta,
+                        "Voter %s has v.weight = %s but should be %s stake_delta: %s unstake_delay: %s time_multiplier: %s max_stake_time: %s",
+                        v.voter, v.weight, weight_delta, stake_delta, unstake_delay, time_multiplier, max_stake_time);
+                }
                 v.weight        = weight_delta;
                 v.weight_quorum = weight_delta_quorum;
             });

--- a/contracts/stakevote/stakevote.hpp
+++ b/contracts/stakevote/stakevote.hpp
@@ -48,7 +48,7 @@ CONTRACT stakevote : public contract {
 
 #ifdef DEBUG
     ACTION clearweights(uint16_t batch_size, name dac_id);
-    ACTION collectwts(uint16_t batch_size, name dac_id);
+    ACTION collectwts(uint16_t batch_size, name dac_id, bool assert);
 #endif
 
     struct [[eosio::table("stakes"), eosio::contract("eosdactokens")]] stake_info {


### PR DESCRIPTION
The bug is most likely caused by an incorrect calculation in collectwts. When the user has a staketime set that differs from the default, collectwts would not take this into account, leading to wrong initial values. This PR:

- Fixes collectwts (see above)
- adds an assert parameter to collectwts to aid in debugging
- Improves several error messages to be more helpful to the user and in potential future debugging

Deployment instruction: In order to fix the bug in mainnet, the new version of the contract compiled with DEBUG flag must be deployed and collectwts must be run for all dacs.