### PR TITLE
Demzne 1123 eosdac fix tests after recent changes

### DIFF
--- a/contracts/dacproposals/dacproposals.test.ts
+++ b/contracts/dacproposals/dacproposals.test.ts
@@ -766,7 +766,7 @@ describe('Dacproposals', () => {
     context('with more denied than approved votes', async () => {
       context('with insufficient votes', async () => {
         before(async () => {
-          for (const custodian of propDacCustodians) {
+          for (const custodian of propDacCustodians.slice(1)) {
             await shared.dacproposals_contract.voteprop(
               custodian.name,
               newpropid,

--- a/contracts/msigworlds/msigworlds.hpp
+++ b/contracts/msigworlds/msigworlds.hpp
@@ -261,10 +261,19 @@ class [[eosio::contract("msigworlds")]] multisig : public eosio::contract {
     void assertValidCustodian(const name proposer, const name dac_id) {
         const auto dac                = eosdac::dacdir::dac_for_id(dac_id);
         const auto custodian_contract = dac.account_for_type_maybe(eosdac::dacdir::CUSTODIAN);
+
         if (custodian_contract) {
-            const auto custodians   = eosdac::custodians_table{*custodian_contract, dac_id.value};
-            const auto is_custodian = custodians.find(proposer.value) != custodians.end();
-            check(is_custodian, "ERR::MUST_BE_CUSTODIAN:: %s must be active custodian.", proposer);
+            const auto custodians          = eosdac::custodians_table{*custodian_contract, dac_id.value};
+            const auto is_custodian        = custodians.find(proposer.value) != custodians.end();
+            const auto referendum_contract = dac.account_for_type_maybe(eosdac::dacdir::REFERENDUM);
+
+            if (referendum_contract) {
+                if (proposer != *referendum_contract) {
+                    check(is_custodian, "ERR::MUST_BE_CUSTODIAN:: %s must be active custodian.", proposer);
+                }
+            } else {
+                check(is_custodian, "ERR::MUST_BE_CUSTODIAN:: %s must be active custodian.", proposer);
+            }
         }
     }
 };

--- a/contracts/stakevote/stakevote.test.ts
+++ b/contracts/stakevote/stakevote.test.ts
@@ -216,10 +216,10 @@ describe('Stakevote', () => {
             from: staker,
           }
         );
-        await shared.dac_token_contract.unstake(staker.name, '0.9989 STADAC', {
+        await shared.dac_token_contract.unstake(staker.name, '0.9983 STADAC', {
           from: staker,
         });
-        await shared.dac_token_contract.unstake(staker.name, '0.0001 STADAC', {
+        await shared.dac_token_contract.unstake(staker.name, '0.0007 STADAC', {
           from: staker,
         });
       });


### PR DESCRIPTION
This PR
* allows the referendum contract to propose proposals without being a custodian'
* updates tests to prevent duplicate transaction errors