### PR TITLE
Fix invalid unsigned subtraction in eosdactoken::staketime

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -13,6 +13,7 @@
 #include "eosdactokens_shared.hpp"
 #include "external_types.hpp"
 #include "safemath/safemath.hpp"
+#include "safemath/serr.hpp"
 #include "safemath/util.hpp"
 
 using namespace std;
@@ -126,6 +127,7 @@ namespace eosdac {
         eosio::time_point_sec avg_vote_time_stamp;
 
         uint64_t calc_decayed_votes_index() const {
+            auto err = Err{"calc_decayed_votes_index"};
             // log(0) is -infinity, so we always add 1. This does not change the order of the index.
             const auto log_arg = S{total_vote_power} + S{1ull};
             const auto log     = log2(log_arg.to<double>());

--- a/contracts/daccustodian/privatehelpers.cpp
+++ b/contracts/daccustodian/privatehelpers.cpp
@@ -3,7 +3,7 @@ using namespace eosdac;
 
 void daccustodian::updateVoteWeight(
     name custodian, const time_point_sec vote_time_stamp, int64_t weight, name dac_id, bool from_voting) {
-
+    auto err = Err{"daccustodian::updateVoteWeight"};
     if (weight == 0) {
         print("Vote has no weight - No need to continue. ");
         return;
@@ -42,6 +42,7 @@ void daccustodian::updateVoteWeight(
 
 time_point_sec daccustodian::calculate_avg_vote_time_stamp(const time_point_sec vote_time_before,
     const time_point_sec vote_time_stamp, const int64_t weight, const uint64_t total_votes) {
+    auto err = Err{"daccustodian::calculate_avg_vote_time_stamp"};
 
     const auto initial     = S{vote_time_before.sec_since_epoch()}.to<int128_t>();
     const auto current     = S{vote_time_stamp.sec_since_epoch()}.to<int128_t>();
@@ -87,6 +88,7 @@ std::pair<int64_t, int64_t> daccustodian::get_vote_weight(name voter, name dac_i
 void daccustodian::modifyVoteWeights(const account_weight_delta &awd, const vector<name> &oldVotes,
     const std::optional<time_point_sec> &oldVoteTimestamp, const vector<name> &newVotes, const name dac_id,
     const bool from_voting) {
+    auto err = Err{"daccustodian::modifyVoteWeights"};
     // This could be optimised with set diffing to avoid remove then add for unchanged votes. - later
 
     if (awd.weight_delta == 0) {

--- a/contracts/stakevote/stakevote.cpp
+++ b/contracts/stakevote/stakevote.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 
 void stakevote::stakeobsv(const vector<account_stake_delta> &stake_deltas, const name dac_id) {
+    auto       err                = Err{"stakevote::stakeobsv"};
     const auto dac                = dacdir::dac_for_id(dac_id);
     const auto token_contract     = dac.symbol.get_contract();
     const auto custodian_contract = dac.account_for_type_maybe(dacdir::CUSTODIAN);
@@ -62,7 +63,8 @@ void stakevote::stakeobsv(const vector<account_stake_delta> &stake_deltas, const
             });
         }
 
-        weight_deltas.push_back({asd.account, weight_delta.to<int64_t>("stakeobsv weight_delta"), weight_delta_quorum});
+        weight_deltas.push_back(
+            {asd.account, weight_delta.to<int64_t>("stakeobsv weight_delta 2"), weight_delta_quorum});
     }
 
     if (custodian_contract) {

--- a/contracts/stakevote/stakevote.test.ts
+++ b/contracts/stakevote/stakevote.test.ts
@@ -7,6 +7,7 @@ import {
   assertRowsEqual,
   UpdateAuth,
   Asset,
+  sleep,
 } from 'lamington';
 import { SharedTestObjects, NUMBER_OF_CANDIDATES } from '../TestHelpers';
 import * as chai from 'chai';
@@ -42,6 +43,7 @@ describe('Stakevote', () => {
     let stake_amount = new Asset(1000, symbol);
     let stake_delay = 2 * years;
     let default_staketime = 2 * days;
+    let max_stake_time = 7776000;
     let time_multiplier = 4;
     let regMembers: Account[];
     let candidates: Account[];
@@ -56,7 +58,7 @@ describe('Stakevote', () => {
         {
           enabled: true,
           min_stake_time: 2 * days,
-          max_stake_time: stake_delay,
+          max_stake_time,
         },
         `${precision},${symbol}`,
         { from: shared.auth_account }
@@ -159,7 +161,7 @@ describe('Stakevote', () => {
           {
             enabled: true,
             min_stake_time: 2 * days,
-            max_stake_time: stake_delay,
+            max_stake_time,
           },
           `${precision},${symbol}`,
           { from: shared.auth_account }
@@ -405,7 +407,7 @@ describe('Stakevote', () => {
           });
 
           const max_stake_time = res.rows[0].max_stake_time;
-          chai.expect(max_stake_time).to.equal(stake_delay);
+          chai.expect(max_stake_time).to.equal(max_stake_time);
         });
         it('before voting: total_weight_of_votes', async () => {
           total_weight_of_votes_before = await get_from_dacglobals(
@@ -456,6 +458,7 @@ describe('Stakevote', () => {
       });
       context('staking and unstaking repeatedly', async () => {
         it('should work', async () => {
+          await sleep(1000);
           await shared.dac_token_contract.transfer(
             shared.tokenIssuer.name,
             voter.name,


### PR DESCRIPTION
This PR fixes an "invalid unsigned subtraction" error that may occur when calling eosdactoken::staketime caused by rounding differences.