### PR TITLE
make migraterank accessible in debug build

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -504,9 +504,12 @@ namespace eosdac {
         ACTION clearcands(const name &dac_id);
 #endif
 
-#ifdef IS_DEV
+#if defined(IS_DEV) || defined(DEBUG)
         ACTION migraterank(const name &dac_id);
         ACTION clearrank(const name &dac_id);
+#endif
+
+#ifdef IS_DEV
         ACTION fillstate(const name &dac_id);
 
         // helper function for testing to add custodian to custodians table without the need for elections

--- a/contracts/daccustodian/voting.cpp
+++ b/contracts/daccustodian/voting.cpp
@@ -191,10 +191,10 @@ ACTION daccustodian::voteproxy(const name &voter, const name &proxyName, const n
     modifyProxiesWeight(vote_weight, oldProxy, newProxy, dac_id, true);
 }
 
-#ifdef IS_DEV
+#if defined(IS_DEV) || defined(DEBUG)
 // Used for testing migraterank
 void daccustodian::clearrank(const name &dac_id) {
-
+    require_auth(get_self());
     auto candidates = candidates_table{get_self(), dac_id.value};
     for (auto &candidate : candidates) {
         candidates.modify(candidate, same_payer, [&](auto &c) {
@@ -205,6 +205,7 @@ void daccustodian::clearrank(const name &dac_id) {
 
 // Needs to be called for every dac after deployment to fill the index (rank field)
 void daccustodian::migraterank(const name &dac_id) {
+    require_auth(get_self());
     auto candidates = candidates_table{get_self(), dac_id.value};
     for (auto &candidate : candidates) {
         candidates.modify(candidate, same_payer, [&](auto &c) {


### PR DESCRIPTION
So we can run it after deployment to update the decayed votes index