### PR TITLE
Demzne 1131 copy rank over to custodians in newperiod

### DIFF
--- a/contracts/daccustodian/daccustodian.cpp
+++ b/contracts/daccustodian/daccustodian.cpp
@@ -22,5 +22,7 @@
 #include "debug.cpp"
 #endif
 
+#include "migration.cpp"
+
 using namespace eosio;
 using namespace std;

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -13,7 +13,7 @@ import {
   assertBalanceEqual,
   Asset,
 } from 'lamington';
-
+const _ = require('lodash');
 import {
   SharedTestObjects,
   NUMBER_OF_CANDIDATES,
@@ -1733,27 +1733,47 @@ describe('Daccustodian', () => {
                 number_of_custodians
               );
             });
+            it('Candidates bydecayed index should sort by rank descending', async () => {
+              const res = await shared.daccustodian_contract.candidatesTable({
+                scope: dacId,
+                limit: 100,
+                indexPosition: 6, // bydecayed index
+                keyType: 'i64',
+              });
+              const unsorted = res.rows;
+              const sorted = _.sortBy(res.rows, (x) => -x.rank);
+              chai.expect(unsorted).to.deep.equal(sorted);
+            });
             it('Should have highest ranked votes in custodians', async () => {
-              let rowsResult =
-                await shared.daccustodian_contract.custodiansTable({
-                  scope: dacId,
-                  limit: 14,
-                  indexPosition: 3,
-                  keyType: 'i64',
-                });
-              let rs = rowsResult.rows;
-              rs.sort((a, b) => {
-                return a.total_vote_power < b.total_vote_power
-                  ? -1
-                  : a.total_vote_power == b.total_vote_power
-                  ? 0
-                  : 1;
-              }).reverse();
-              chai.expect(rs[0].total_vote_power).to.equal(3200000000);
-              chai.expect(rs[1].total_vote_power).to.equal(3200000000);
-              chai.expect(rs[2].total_vote_power).to.equal(3200000000);
-              chai.expect(rs[3].total_vote_power).to.equal(1600000000);
-              chai.expect(rs[4].total_vote_power).to.equal(1600000000);
+              let res1 = await shared.daccustodian_contract.candidatesTable({
+                scope: dacId,
+                limit: 100,
+                indexPosition: 6, // bydecayed index
+                keyType: 'i64',
+              });
+
+              let res2 = await shared.daccustodian_contract.custodiansTable({
+                scope: dacId,
+                limit: 100,
+                indexPosition: 2, // bydecayed index
+                keyType: 'i64',
+              });
+
+              const candidates = res1.rows.map((x) => {
+                return {
+                  cust_name: x.candidate_name,
+                  requestedpay: x.requestedpay,
+                  rank: x.rank,
+                };
+              });
+
+              console.log(
+                'candidates.slice(0, 5): ',
+                JSON.stringify(candidates.slice(0, 5), null, 2)
+              );
+              console.log('res2.rows: ', JSON.stringify(res2.rows, null, 2));
+              chai.expect(res2.rows.length).to.equal(5);
+              chai.expect(candidates.slice(0, 5)).to.deep.equal(res2.rows);
             });
             it('Custodians should not yet be paid', async () => {
               await assertRowCount(
@@ -2930,7 +2950,7 @@ describe('Daccustodian', () => {
       chai.expect(candidates.rows.length).equals(5);
 
       chai.expect(candidates.rows[0].requestedpay).to.equal('0.0000 EOS');
-      chai.expect(candidates.rows[0].total_vote_power).to.equal(0);
+      chai.expect(candidates.rows[0].rank).to.equal(0);
       chai.expect(candidates.rows[0].number_voters).to.equal(0);
       chai.expect(candidates.rows[0].is_active).to.equal(1);
 
@@ -2941,7 +2961,7 @@ describe('Daccustodian', () => {
       chai.expect(custodians.rows.length).equals(5);
 
       chai.expect(custodians.rows[0].requestedpay).to.equal('0.0000 EOS');
-      chai.expect(custodians.rows[0].total_vote_power).to.equal(0);
+      chai.expect(custodians.rows[0].rank).to.equal(0);
     });
     it('should fail with existing custodians appointed', async () => {
       await assertEOSErrorIncludesMessage(

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -49,6 +49,98 @@ describe('Daccustodian', () => {
     somebody = await AccountManager.createAccount();
   });
 
+  context('Migration', async () => {
+    let dacId = 'migratecust';
+    const date = new Date(0);
+    let table_contents = [
+      {
+        cust_name: 'testcust1',
+        requestedpay: '0.0000 TLM',
+        rank: 0,
+        total_vote_power: 0,
+        number_voters: 0,
+        avg_vote_time_stamp: date,
+      },
+      {
+        cust_name: 'testcust2',
+        requestedpay: '0.0000 TLM',
+        rank: 0,
+        total_vote_power: 0,
+        number_voters: 0,
+        avg_vote_time_stamp: date,
+      },
+      {
+        cust_name: 'testcust3',
+        requestedpay: '0.0000 TLM',
+        rank: 0,
+        total_vote_power: 0,
+        number_voters: 0,
+        avg_vote_time_stamp: date,
+      },
+      {
+        cust_name: 'testcust4',
+        requestedpay: '0.0000 TLM',
+        rank: 0,
+        total_vote_power: 0,
+        number_voters: 0,
+        avg_vote_time_stamp: date,
+      },
+      {
+        cust_name: 'testcust5',
+        requestedpay: '0.0000 TLM',
+        rank: 0,
+        total_vote_power: 0,
+        number_voters: 0,
+        avg_vote_time_stamp: date,
+      },
+    ];
+    it('adding test custodians should work', async () => {
+      await shared.daccustodian_contract.tstaddcust('testcust1', dacId);
+      await shared.daccustodian_contract.tstaddcust('testcust2', dacId);
+      await shared.daccustodian_contract.tstaddcust('testcust3', dacId);
+      await shared.daccustodian_contract.tstaddcust('testcust4', dacId);
+      await shared.daccustodian_contract.tstaddcust('testcust5', dacId);
+    });
+    it('should add custodians', async () => {
+      await assertRowsEqual(
+        shared.daccustodian_contract.custodiansTable({
+          scope: dacId,
+        }),
+        table_contents
+      );
+    });
+    it('migrate1 should work', async () => {
+      await shared.daccustodian_contract.migrate1(dacId);
+    });
+    it('should delete custodians', async () => {
+      await assertRowsEqual(
+        shared.daccustodian_contract.custodiansTable({
+          scope: dacId,
+        }),
+        []
+      );
+    });
+    it('should have migrated to custodians2', async () => {
+      await assertRowsEqual(
+        shared.daccustodian_contract.custodians2Table({
+          scope: dacId,
+        }),
+        table_contents
+      );
+    });
+    it('migrate2 should work', async () => {
+      await shared.daccustodian_contract.migrate2(dacId);
+    });
+    it('should have migrated back to custodians', async () => {
+      await assertRowsEqual(
+        shared.daccustodian_contract.custodiansTable({
+          scope: dacId,
+        }),
+        table_contents
+      );
+    });
+  });
+
   context('fillstate', async () => {
     let dacId = 'migratedac';
     before(async () => {

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -1856,6 +1856,9 @@ describe('Daccustodian', () => {
                   cust_name: x.candidate_name,
                   requestedpay: x.requestedpay,
                   rank: x.rank,
+                  total_vote_power: x.total_vote_power,
+                  number_voters: x.number_voters,
+                  avg_vote_time_stamp: x.avg_vote_time_stamp,
                 };
               });
 

--- a/contracts/daccustodian/migration.cpp
+++ b/contracts/daccustodian/migration.cpp
@@ -4,9 +4,7 @@ ACTION daccustodian::migrate1(const name dac_id) {
     auto custodians  = custodians_table{get_self(), dac_id.value};
     auto custodians2 = custodians2_table{get_self(), dac_id.value};
     auto itr         = custodians.begin();
-    print("DBG: ");
     while (itr != custodians.end()) {
-        print(fmt("Migrating custodian %s ", itr->cust_name));
         custodians2.emplace(get_self(), [&](auto &c) {
             c.cust_name    = itr->cust_name;
             c.requestedpay = itr->requestedpay;

--- a/contracts/daccustodian/migration.cpp
+++ b/contracts/daccustodian/migration.cpp
@@ -6,9 +6,9 @@ ACTION daccustodian::migrate1(const name dac_id) {
     auto itr         = custodians.begin();
     while (itr != custodians.end()) {
         custodians2.emplace(get_self(), [&](auto &c) {
-            c.cust_name    = itr->cust_name;
-            c.requestedpay = itr->requestedpay;
-            c.rank         = itr->rank;
+            c.cust_name        = itr->cust_name;
+            c.requestedpay     = itr->requestedpay;
+            c.total_vote_power = itr->total_vote_power;
         });
         itr = custodians.erase(itr);
     }
@@ -20,9 +20,9 @@ ACTION daccustodian::migrate2(const name dac_id) {
     auto itr         = custodians2.begin();
     while (itr != custodians2.end()) {
         custodians.emplace(get_self(), [&](auto &c) {
-            c.cust_name    = itr->cust_name;
-            c.requestedpay = itr->requestedpay;
-            c.rank         = itr->rank;
+            c.cust_name        = itr->cust_name;
+            c.requestedpay     = itr->requestedpay;
+            c.total_vote_power = itr->total_vote_power;
         });
         itr = custodians2.erase(itr);
     }

--- a/contracts/daccustodian/migration.cpp
+++ b/contracts/daccustodian/migration.cpp
@@ -1,0 +1,32 @@
+
+
+ACTION daccustodian::migrate1(const name dac_id) {
+    auto custodians  = custodians_table{get_self(), dac_id.value};
+    auto custodians2 = custodians2_table{get_self(), dac_id.value};
+    auto itr         = custodians.begin();
+    print("DBG: ");
+    while (itr != custodians.end()) {
+        print(fmt("Migrating custodian %s ", itr->cust_name));
+        custodians2.emplace(get_self(), [&](auto &c) {
+            c.cust_name    = itr->cust_name;
+            c.requestedpay = itr->requestedpay;
+            c.rank         = itr->rank;
+        });
+        itr = custodians.erase(itr);
+    }
+}
+#ifdef MIGRATION_STAGE_2
+ACTION daccustodian::migrate2(const name dac_id) {
+    auto custodians  = custodians_table{get_self(), dac_id.value};
+    auto custodians2 = custodians2_table{get_self(), dac_id.value};
+    auto itr         = custodians2.begin();
+    while (itr != custodians2.end()) {
+        custodians.emplace(get_self(), [&](auto &c) {
+            c.cust_name    = itr->cust_name;
+            c.requestedpay = itr->requestedpay;
+            c.rank         = itr->rank;
+        });
+        itr = custodians2.erase(itr);
+    }
+}
+#endif

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -104,9 +104,9 @@ void daccustodian::allocateCustodians(bool early_election, name dac_id) {
             cand_itr++;
         } else {
             custodians.emplace(auth_account, [&](custodian &c) {
-                c.cust_name        = cand_itr->candidate_name;
-                c.requestedpay     = cand_itr->requestedpay;
-                c.total_vote_power = cand_itr->total_vote_power;
+                c.cust_name    = cand_itr->candidate_name;
+                c.requestedpay = cand_itr->requestedpay;
+                c.rank         = cand_itr->rank;
             });
 
             currentCustodianCount++;
@@ -145,7 +145,7 @@ void daccustodian::add_auth_to_account(const name &accountToChange, const uint8_
         .send();
 }
 
-void daccustodian::add_all_auths(const name &           accountToChange,
+void daccustodian::add_all_auths(const name            &accountToChange,
     const vector<eosiosystem::permission_level_weight> &weights, const name &dac_id, const bool msig) {
     const auto globals = dacglobals::current(get_self(), dac_id);
 

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -104,9 +104,14 @@ void daccustodian::allocateCustodians(bool early_election, name dac_id) {
             cand_itr++;
         } else {
             custodians.emplace(auth_account, [&](custodian &c) {
-                c.cust_name    = cand_itr->candidate_name;
-                c.requestedpay = cand_itr->requestedpay;
-                c.rank         = cand_itr->rank;
+                c.cust_name        = cand_itr->candidate_name;
+                c.requestedpay     = cand_itr->requestedpay;
+                c.total_vote_power = cand_itr->total_vote_power;
+#ifdef MIGRATION_STAGE_2
+                c.rank                = cand_itr->rank;
+                c.number_voters       = cand_itr->number_voters;
+                c.avg_vote_time_stamp = cand_itr->avg_vote_time_stamp;
+#endif
             });
 
             currentCustodianCount++;

--- a/contracts/daccustodian/registering.cpp
+++ b/contracts/daccustodian/registering.cpp
@@ -140,7 +140,6 @@ ACTION daccustodian::appointcust(const vector<name> &custs, const name &dac_id) 
         custodians.emplace(auth_account, [&](custodian &c) {
             c.cust_name    = cust;
             c.requestedpay = req_pay.quantity;
-            c.rank         = 0;
         });
     }
 }

--- a/contracts/daccustodian/registering.cpp
+++ b/contracts/daccustodian/registering.cpp
@@ -138,9 +138,9 @@ ACTION daccustodian::appointcust(const vector<name> &custs, const name &dac_id) 
         }
 
         custodians.emplace(auth_account, [&](custodian &c) {
-            c.cust_name        = cust;
-            c.requestedpay     = req_pay.quantity;
-            c.total_vote_power = 0;
+            c.cust_name    = cust;
+            c.requestedpay = req_pay.quantity;
+            c.rank         = 0;
         });
     }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dayjs": "^1.11.1",
     "deep-equal-in-any-order": "^1.1.19",
     "eslint": "^8.8.0",
+    "lodash": "^4.17.21",
     "moment": "^2.29.3",
     "typescript-logging": "^0.6.3"
   }


### PR DESCRIPTION
This PR

- Renames the field total_vote_power to rank and re-uses it to store the rank of the candidate at time of newperiod
- Updates daccustodian and stakevote tests to account for the above
- Adds a unit test for the rank calculation to the stakevote tests

This allows the UI to display the rank data for both candidates and custodians.