### PR TITLE
Demzne 1187 fix avg vote time stamp pushed into the future error

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -69,7 +69,7 @@ namespace eosdac {
         uint8_t               is_active;
         uint32_t              number_voters;
         eosio::time_point_sec avg_vote_time_stamp;
-        uint64_t              running_weight_time; // The running sum of weight*time from all votes for this candidate
+        uint128_t             running_weight_time; // The running sum of weight*time from all votes for this candidate
 
         uint64_t calc_decayed_votes_index() const {
             auto       err            = Err{"calc_decayed_votes_index"};

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -124,9 +124,6 @@ namespace eosdac {
         uint8_t               is_active;
         uint32_t              number_voters;
         eosio::time_point_sec avg_vote_time_stamp;
-#ifndef MIGRATION_STAGE_1
-        uint128_t running_weight_time; // The running sum of weight*time from all votes for this candidate
-#endif
 
         uint64_t calc_decayed_votes_index() const {
             auto       err            = Err{"calc_decayed_votes_index"};

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -337,10 +337,10 @@ namespace eosdac {
         ACTION setperm(const name &cand, const name &permission, const name &dac_id);
 
       private: // Private helper methods used by other actions.
-        void updateVoteWeight(name voter, name custodian, const time_point_sec vote_time_stamp, int64_t weight,
-            name dac_id, bool from_voting, const vector<name> &votes);
-        void updateVoteWeights(const name voter, const vector<name> &votes, const time_point_sec vote_time_stamp,
-            int64_t vote_weight, name internal_dac_id, bool from_voting);
+        void updateVoteWeight(
+            name custodian, const time_point_sec vote_time_stamp, int64_t weight, name dac_id, bool from_voting);
+        void updateVoteWeights(const vector<name> &votes, const time_point_sec vote_time_stamp, int64_t vote_weight,
+            name internal_dac_id, bool from_voting);
         std::pair<int64_t, int64_t> get_vote_weight(name voter, name dac_id);
         void                        modifyVoteWeights(const account_weight_delta &awd, const vector<name> &oldVotes,
                                    const std::optional<time_point_sec> &oldVoteTimestamp, const vector<name> &newVotes,

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -307,6 +307,7 @@ namespace eosdac {
             PROPERTY(uint32_t, lockup_release_time_delay);
             PROPERTY(eosio::extended_asset, requested_pay_max); 
             PROPERTY(uint64_t, token_supply_theshold);
+            PROPERTY(bool, maintenance_mode);
     )
     // clang-format on
 
@@ -358,6 +359,7 @@ namespace eosdac {
         ACTION resetcands(const name &dac_id);
         ACTION resetstate(const name &dac_id);
         ACTION clearcands(const name &dac_id);
+        ACTION maintenance(const bool maintenance);
 #endif
 
 #if defined(IS_DEV) || defined(DEBUG)
@@ -437,5 +439,10 @@ namespace eosdac {
         uint16_t       get_budget_percentage(const name &dac_id, const dacglobals &globals);
         time_point_sec calc_avg_vote_time(const candidate &cand);
         void update_number_of_votes(const vector<name> &oldvotes, const vector<name> &newvotes, const name &dac_id);
+
+        bool maintenance_mode() {
+            const auto globals = dacglobals{get_self(), get_self()};
+            return globals.get_maintenance_mode();
+        }
     };
 }; // namespace eosdac

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -163,6 +163,7 @@ namespace eosdac {
         name                  proxy;
         std::vector<name>     candidates;
         eosio::time_point_sec vote_time_stamp;
+        eosio::time_point_sec avg_vote_time_delta;
         uint8_t               vote_count; // wraps around automatically if > 255
 
         uint64_t primary_key() const {
@@ -336,10 +337,10 @@ namespace eosdac {
         ACTION setperm(const name &cand, const name &permission, const name &dac_id);
 
       private: // Private helper methods used by other actions.
-        void updateVoteWeight(
-            name custodian, const time_point_sec vote_time_stamp, int64_t weight, name dac_id, bool from_voting);
-        void updateVoteWeights(const vector<name> &votes, const time_point_sec vote_time_stamp, int64_t vote_weight,
-            name internal_dac_id, bool from_voting);
+        void updateVoteWeight(name voter, name custodian, const time_point_sec vote_time_stamp, int64_t weight,
+            name dac_id, bool from_voting, const vector<name> &votes);
+        void updateVoteWeights(const name voter, const vector<name> &votes, const time_point_sec vote_time_stamp,
+            int64_t vote_weight, name internal_dac_id, bool from_voting);
         std::pair<int64_t, int64_t> get_vote_weight(name voter, name dac_id);
         void                        modifyVoteWeights(const account_weight_delta &awd, const vector<name> &oldVotes,
                                    const std::optional<time_point_sec> &oldVoteTimestamp, const vector<name> &newVotes,
@@ -370,7 +371,7 @@ namespace eosdac {
         void validateUnstakeAmount(const name &code, const name &cand, const asset &unstake_amount, const name &dac_id);
         void validateMinStake(name account, name dac_id);
         uint16_t       get_budget_percentage(const name &dac_id, const dacglobals &globals);
-        time_point_sec calculate_avg_vote_time_stamp(const time_point_sec vote_time_before,
+        time_point_sec calc_avg_vote_time_delta(const time_point_sec vote_time_before,
             const time_point_sec vote_time_stamp, const int64_t weight, const uint64_t total_votes);
         void update_number_of_votes(const vector<name> &oldvotes, const vector<name> &newvotes, const name &dac_id);
     };

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -164,7 +164,6 @@ namespace eosdac {
         name                  proxy;
         std::vector<name>     candidates;
         eosio::time_point_sec vote_time_stamp;
-        eosio::time_point_sec avg_vote_time_delta;
         uint8_t               vote_count; // wraps around automatically if > 255
 
         uint64_t primary_key() const {

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -69,6 +69,7 @@ namespace eosdac {
         uint8_t               is_active;
         uint32_t              number_voters;
         eosio::time_point_sec avg_vote_time_stamp;
+        uint64_t              running_weight_time; // The running sum of weight*time from all votes for this candidate
 
         uint64_t calc_decayed_votes_index() const {
             auto       err            = Err{"calc_decayed_votes_index"};
@@ -371,8 +372,7 @@ namespace eosdac {
         void validateUnstakeAmount(const name &code, const name &cand, const asset &unstake_amount, const name &dac_id);
         void validateMinStake(name account, name dac_id);
         uint16_t       get_budget_percentage(const name &dac_id, const dacglobals &globals);
-        time_point_sec calc_avg_vote_time_delta(const time_point_sec vote_time_before,
-            const time_point_sec vote_time_stamp, const int64_t weight, const uint64_t total_votes);
+        time_point_sec calc_avg_vote_time(const candidate &cand);
         void update_number_of_votes(const vector<name> &oldvotes, const vector<name> &newvotes, const name &dac_id);
     };
 }; // namespace eosdac

--- a/contracts/daccustodian/daccustodian.cpp
+++ b/contracts/daccustodian/daccustodian.cpp
@@ -22,5 +22,7 @@
 #include "debug.cpp"
 #endif
 
+#include "migration.cpp"
+
 using namespace eosio;
 using namespace std;

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -748,39 +748,41 @@ describe('Daccustodian', () => {
     });
     context('After voting', async () => {
       it('only candidates with votes have total_vote_power values 1', async () => {
-        console.log('ohai 1');
+        console.log('ohai vote_and_check 1');
         await vote_and_check(dacId, regMembers[0], cands[0]);
-        console.log('ohai 2');
+        console.log('ohai vote_and_check 2');
         await vote_and_check(dacId, regMembers[0], cands[0]);
-        console.log('ohai 3');
+        console.log('ohai vote_and_check 3');
         await vote_and_check(dacId, regMembers[1], cands[0]);
-        console.log('ohai 4');
-        await vote_and_check(dacId, regMembers[0], cands[0]);
-        console.log('ohai 5');
-        await vote_and_check(dacId, regMembers[0], cands.slice(1, 3));
-        console.log('ohai 6');
-        await vote_and_check(dacId, regMembers[1], cands.slice(1, 3));
-        console.log('ohai 7');
-        await vote_and_check(dacId, regMembers[2], cands.slice(1, 3));
-        console.log('ohai 8');
-        await vote_and_check(dacId, regMembers[2], []);
-        console.log('ohai 9');
-        await vote_and_check(dacId, regMembers[0], cands.slice(2, 4));
-        console.log('ohai 10');
         await vote_and_check(dacId, regMembers[0], []);
-        console.log('ohai 11');
-        await vote_and_check(dacId, regMembers[2], cands.slice(1, 3));
-        console.log('ohai 12');
-        await vote_and_check(dacId, regMembers[2], cands.slice(1, 3));
-        console.log('ohai 13');
-        await vote_and_check(dacId, regMembers[0], cands.slice(1, 3));
-        console.log('ohai 14');
-        await vote_and_check(dacId, regMembers[2], cands.slice(1, 2));
-        console.log('ohai 15');
-        await vote_and_check(dacId, regMembers[1], cands.slice(2, 3));
-        console.log('ohai 16');
-        await vote_and_check(dacId, regMembers[1], []);
-        console.log('ohai 17');
+
+        // console.log('ohai vote_and_check 4');
+        // await vote_and_check(dacId, regMembers[0], cands[0]);
+        // console.log('ohai vote_and_check 5');
+        // await vote_and_check(dacId, regMembers[0], cands.slice(1, 3));
+        // console.log('ohai vote_and_check 6');
+        // await vote_and_check(dacId, regMembers[1], cands.slice(1, 3));
+        // console.log('ohai vote_and_check 7');
+        // await vote_and_check(dacId, regMembers[2], cands.slice(1, 3));
+        // console.log('ohai vote_and_check 8');
+        // await vote_and_check(dacId, regMembers[2], []);
+        // console.log('ohai vote_and_check 9');
+        // await vote_and_check(dacId, regMembers[0], cands.slice(2, 4));
+        // console.log('ohai vote_and_check 10');
+        // await vote_and_check(dacId, regMembers[0], []);
+        // console.log('ohai vote_and_check 11');
+        // await vote_and_check(dacId, regMembers[2], cands.slice(1, 3));
+        // console.log('ohai vote_and_check 12');
+        // await vote_and_check(dacId, regMembers[2], cands.slice(1, 3));
+        // console.log('ohai vote_and_check 13');
+        // await vote_and_check(dacId, regMembers[0], cands.slice(1, 3));
+        // console.log('ohai vote_and_check 14');
+        // await vote_and_check(dacId, regMembers[2], cands.slice(1, 2));
+        // console.log('ohai vote_and_check 15');
+        // await vote_and_check(dacId, regMembers[1], cands.slice(2, 3));
+        // console.log('ohai vote_and_check 16');
+        // await vote_and_check(dacId, regMembers[1], []);
+        console.log('ohai vote_and_check 17');
       });
     });
   });
@@ -3706,31 +3708,40 @@ async function vote_and_check(dacId, voter, candidates) {
   let expected_avg_cand = {};
   for (const candidate of candidates) {
     let x = await get_expected_avg_vote_time_stamp(dacId, voter, candidate);
-    console.log(
-      `OHAI candidate ${candidate.name} expected avg_vote_time_stamp ${x}`
-    );
+    // console.log(
+    //   `OHAI candidate ${candidate.name} expected avg_vote_time_stamp ${x}`
+    // );
     chai.expect(x).to.not.be.undefined;
     expected_avg_cand[candidate.name] = x;
   }
-  console.log('expected_avg_cand', JSON.stringify(expected_avg_cand, null, 2));
+
+  await shared.daccustodian_contract.votecust(
+    voter.name,
+    candidates.map((x) => x.name),
+    dacId,
+    {
+      from: voter,
+    }
+  );
+
+  // console.log('expected_avg_cand', JSON.stringify(expected_avg_cand, null, 2));
   for (const candidate of candidates) {
-    await shared.daccustodian_contract.votecust(
-      voter.name,
-      [candidate.name],
-      dacId,
-      { from: voter }
-    );
     let votedCandidateResult =
       await shared.daccustodian_contract.candidatesTable({
         scope: dacId,
-        limit: 1,
         lowerBound: candidate.name,
       });
+    const votedCandidate = votedCandidateResult.rows.find(
+      (x) => x.candidate_name == candidate.name
+    );
+    chai.expect(votedCandidate.candidate_name).to.equal(candidate.name);
+    console.log(
+      `OHAI candidate ${candidate.name} avg_vote_time_stamp ${
+        votedCandidate.avg_vote_time_stamp
+      } expected_avg_cand[candidate.name]: ${expected_avg_cand[candidate.name]}`
+    );
     chai
-      .expect(votedCandidateResult.rows[0].candidate_name)
-      .to.equal(candidate.name);
-    chai
-      .expect(votedCandidateResult.rows[0].avg_vote_time_stamp)
+      .expect(votedCandidate.avg_vote_time_stamp)
       .to.closeToTime(expected_avg_cand[candidate.name], 3);
   }
 }

--- a/contracts/daccustodian/debug.cpp
+++ b/contracts/daccustodian/debug.cpp
@@ -65,3 +65,10 @@ void daccustodian::clearcands(const name &dac_id) {
         cand = candidates.erase(cand);
     }
 }
+
+void daccustodian::maintenance(const bool maintenance) {
+    require_auth(get_self());
+
+    auto globals = dacglobals{get_self(), get_self()};
+    globals.set_maintenance_mode(maintenance);
+}

--- a/contracts/daccustodian/debug.cpp
+++ b/contracts/daccustodian/debug.cpp
@@ -45,6 +45,9 @@ void daccustodian::resetcands(const name &dac_id) {
             c.number_voters    = 0;
             // c.is_active           = 0;
             c.avg_vote_time_stamp = eosio::time_point_sec();
+#ifndef MIGRATION_STAGE_1
+            c.running_weight_time = 0;
+#endif
             c.update_index();
         });
 

--- a/contracts/daccustodian/external_observable_actions.cpp
+++ b/contracts/daccustodian/external_observable_actions.cpp
@@ -20,6 +20,8 @@ ACTION daccustodian::weightobsv(const vector<account_weight_delta> &account_weig
     auto dac            = dacdir::dac_for_id(dac_id);
     auto token_contract = dac.symbol.get_contract();
 
+    check(!maintenance_mode(), "Maintenance mode. Please try again in a few minutes");
+
     const auto router_account = dac.account_for_type_maybe(dacdir::VOTE_WEIGHT);
 
     check(has_auth(token_contract) || (router_account && has_auth(*router_account)),

--- a/contracts/daccustodian/migration.cpp
+++ b/contracts/daccustodian/migration.cpp
@@ -1,0 +1,40 @@
+
+ACTION daccustodian::migrate1(const name dac_id) {
+    auto candidates  = candidates_table{get_self(), dac_id.value};
+    auto candidates2 = candidates2_table{get_self(), dac_id.value};
+    auto itr         = candidates.begin();
+    while (itr != candidates.end()) {
+        candidates2.emplace(get_self(), [&](auto &c) {
+            c.candidate_name      = itr->candidate_name;
+            c.requestedpay        = itr->requestedpay;
+            c.rank                = itr->rank;
+            c.gap_filler          = itr->gap_filler;
+            c.total_vote_power    = itr->total_vote_power;
+            c.is_active           = itr->is_active;
+            c.number_voters       = itr->number_voters;
+            c.avg_vote_time_stamp = itr->avg_vote_time_stamp;
+        });
+        itr = candidates.erase(itr);
+    }
+}
+
+#ifndef MIGRATION_STAGE_1
+ACTION daccustodian::migrate2(const name dac_id) {
+    auto candidates  = candidates_table{get_self(), dac_id.value};
+    auto candidates2 = candidates2_table{get_self(), dac_id.value};
+    auto itr         = candidates2.begin();
+    while (itr != candidates2.end()) {
+        candidates.emplace(get_self(), [&](auto &c) {
+            c.candidate_name      = itr->candidate_name;
+            c.requestedpay        = itr->requestedpay;
+            c.rank                = itr->rank;
+            c.gap_filler          = itr->gap_filler;
+            c.total_vote_power    = itr->total_vote_power;
+            c.is_active           = itr->is_active;
+            c.number_voters       = itr->number_voters;
+            c.avg_vote_time_stamp = itr->avg_vote_time_stamp;
+        });
+        itr = candidates2.erase(itr);
+    }
+}
+#endif

--- a/contracts/daccustodian/privatehelpers.cpp
+++ b/contracts/daccustodian/privatehelpers.cpp
@@ -27,8 +27,8 @@ void daccustodian::updateVoteWeight(
             c.total_vote_power = new_vote_power.to<uint64_t>();
         }
 
-        c.running_weight_time = S<uint64_t>{c.running_weight_time}.add_signed_to_unsigned(
-            S{weight} * S{vote_time_stamp.sec_since_epoch()}.to<int64_t>());
+        c.running_weight_time = S<uint128_t>{c.running_weight_time}.add_signed_to_unsigned(
+            S{weight}.to<int128_t>() * S{vote_time_stamp.sec_since_epoch()}.to<int128_t>());
 
         c.avg_vote_time_stamp = calc_avg_vote_time(c);
 
@@ -42,7 +42,7 @@ time_point_sec daccustodian::calc_avg_vote_time(const candidate &cand) {
     if (cand.total_vote_power == 0) {
         return time_point_sec(0);
     }
-    const auto delta = S{cand.running_weight_time} / S{cand.total_vote_power};
+    const auto delta = S{cand.running_weight_time} / S{cand.total_vote_power}.to<uint128_t>();
     return time_point_sec{delta.to<uint32_t>()};
 }
 

--- a/contracts/daccustodian/privatehelpers.cpp
+++ b/contracts/daccustodian/privatehelpers.cpp
@@ -26,10 +26,10 @@ void daccustodian::updateVoteWeight(
         } else {
             c.total_vote_power = new_vote_power.to<uint64_t>();
         }
-
+#ifndef MIGRATION_STAGE_1
         c.running_weight_time = S<uint128_t>{c.running_weight_time}.add_signed_to_unsigned(
             S{weight}.to<int128_t>() * S{vote_time_stamp.sec_since_epoch()}.to<int128_t>());
-
+#endif
         c.avg_vote_time_stamp = calc_avg_vote_time(c);
 
         check(c.avg_vote_time_stamp <= now(), "avg_vote_time_stamp pushed into the future: %s", c.avg_vote_time_stamp);
@@ -42,7 +42,11 @@ time_point_sec daccustodian::calc_avg_vote_time(const candidate &cand) {
     if (cand.total_vote_power == 0) {
         return time_point_sec(0);
     }
+#ifndef MIGRATION_STAGE_1
     const auto delta = S{cand.running_weight_time} / S{cand.total_vote_power}.to<uint128_t>();
+#else
+    const auto delta = S{0};
+#endif
     return time_point_sec{delta.to<uint32_t>()};
 }
 

--- a/contracts/daccustodian/voting.cpp
+++ b/contracts/daccustodian/voting.cpp
@@ -24,8 +24,8 @@ ACTION daccustodian::votecust(const name &voter, const vector<name> &newvotes, c
     }
 
     // Find a vote that has been cast by this voter previously.
-    votes_table votes_cast_by_members(_self, dac_id.value);
-    auto        existingVote = votes_cast_by_members.find(voter.value);
+    auto votes_cast_by_members = votes_table{_self, dac_id.value};
+    auto existingVote          = votes_cast_by_members.find(voter.value);
 
     const auto [vote_weight, vote_weight_quorum] = get_vote_weight(voter, dac_id);
     if (existingVote != votes_cast_by_members.end()) {
@@ -34,30 +34,17 @@ ACTION daccustodian::votecust(const name &voter, const vector<name> &newvotes, c
         modifyVoteWeights({voter, vote_weight, vote_weight_quorum}, existingVote->candidates,
             existingVote->vote_time_stamp, newvotes, now(), dac_id, true);
 
-        if (newvotes.size() == 0) {
-            // Remove the vote if the array of candidates is empty
-            votes_cast_by_members.erase(existingVote);
-            eosio::print("\n Removing empty vote.");
-        } else {
-            votes_cast_by_members.modify(existingVote, voter, [&](vote &v) {
-                v.candidates      = newvotes;
-                v.proxy           = name();
-                v.vote_time_stamp = now();
-                v.vote_count++;
-            });
-        }
-
     } else {
         update_number_of_votes({}, newvotes, dac_id);
 
         modifyVoteWeights({voter, vote_weight, vote_weight_quorum}, {}, {}, newvotes, now(), dac_id, true);
 
-        votes_cast_by_members.emplace(voter, [&](vote &v) {
-            v.voter           = voter;
-            v.candidates      = newvotes;
-            v.vote_time_stamp = now();
-            v.vote_count      = 0;
-        });
+        // votes_cast_by_members.emplace(voter, [&](vote &v) {
+        //     v.voter           = voter;
+        //     v.candidates      = newvotes;
+        //     v.vote_time_stamp = now();
+        //     v.vote_count      = 0;
+        // });
     }
 }
 

--- a/contracts/daccustodian/voting.cpp
+++ b/contracts/daccustodian/voting.cpp
@@ -8,6 +8,8 @@ ACTION daccustodian::votecust(const name &voter, const vector<name> &newvotes, c
     candidates_table registered_candidates(_self, dac_id.value);
     const auto       globals = dacglobals{get_self(), dac_id};
 
+    check(!maintenance_mode(), "Voting is currently disabled for maintenance. Please try again in a few minutes");
+
     require_auth(voter);
     assertValidMember(voter, dac_id);
     check(newvotes.size() <= globals.get_maxvotes(),

--- a/contracts/daccustodian/voting.cpp
+++ b/contracts/daccustodian/voting.cpp
@@ -34,17 +34,30 @@ ACTION daccustodian::votecust(const name &voter, const vector<name> &newvotes, c
         modifyVoteWeights({voter, vote_weight, vote_weight_quorum}, existingVote->candidates,
             existingVote->vote_time_stamp, newvotes, now(), dac_id, true);
 
+        if (newvotes.size() == 0) {
+            // Remove the vote if the array of candidates is empty
+            votes_cast_by_members.erase(existingVote);
+            eosio::print("\n Removing empty vote.");
+        } else {
+            votes_cast_by_members.modify(existingVote, voter, [&](vote &v) {
+                v.candidates      = newvotes;
+                v.proxy           = name();
+                v.vote_time_stamp = now();
+                v.vote_count++;
+            });
+        }
+
     } else {
         update_number_of_votes({}, newvotes, dac_id);
 
         modifyVoteWeights({voter, vote_weight, vote_weight_quorum}, {}, {}, newvotes, now(), dac_id, true);
 
-        // votes_cast_by_members.emplace(voter, [&](vote &v) {
-        //     v.voter           = voter;
-        //     v.candidates      = newvotes;
-        //     v.vote_time_stamp = now();
-        //     v.vote_count      = 0;
-        // });
+        votes_cast_by_members.emplace(voter, [&](vote &v) {
+            v.voter           = voter;
+            v.candidates      = newvotes;
+            v.vote_time_stamp = now();
+            v.vote_count      = 0;
+        });
     }
 }
 


### PR DESCRIPTION
This PR changes the vote decay implementation to a more robust algorithm. 

The new field `running_weight_time` needs to be `uint128_t` as `uint64_t` would potentially not be large enough to hold expected values. That's why the existing `gap_filler` field cannot be reused for this and we need to migrate the candidates table.

Migration steps:

1. Compile code with `yarn build -p daccustodian -DMIGRATION_STAGE_1 -DDEBUG` and deploy
2. Enable maintenance mode by executing the ACTION `maintenance(true)`.
3. Execute `migrate1(dac_id)` action for all DACs to move all data from candidates table to candidates2 temp table.
4. Compile code without MIGRATION_STAGE_1 flag (only with DEBUG) like this: `yarn build -p daccustodian -DDEBUG` and deploy
5. Execute `migrate2(dac_id)` action for all DACs to move all data from temp candidates2 table to candidates table.
6. Run `resetcands`, `resetstate` and `collectvotes` for all DACs to populate new field `running_weight_time` with the correct data.
7. Disable maintenance mode by executing ACTION `maintenance(false)`
8. Optional: Build contract without -DDEBUG and re-deploy.