### PR TITLE
Refactors for the referendum contract to be more usable for the community

### DIFF
--- a/contracts/dacproposals/dacproposals.test.ts
+++ b/contracts/dacproposals/dacproposals.test.ts
@@ -39,7 +39,7 @@ enum ProposalState {
 const proposalHash = 'jhsdfkjhsdfkjhkjsdf';
 let planet: Account;
 
-describe.only('Dacproposals', () => {
+describe('Dacproposals', () => {
   let otherAccount: Account;
   let proposer1Account: Account;
   let arbitrator: Account;

--- a/contracts/referendum/referendum.cpp
+++ b/contracts/referendum/referendum.cpp
@@ -273,10 +273,6 @@ void referendum::cancel(name referendum_id, name dac_id) {
 void referendum::exec(name referendum_id, name dac_id) {
     checkDAC(dac_id);
 
-    action(eosio::permission_level{get_self(), "active"_n}, get_self(), "updatestatus"_n,
-        make_tuple(referendum_id, dac_id))
-        .send();
-
     referenda_table referenda(get_self(), dac_id.value);
     auto            ref = referenda.require_find(referendum_id.value, "ERR:REFERENDUM_NOT_FOUND::Referendum not found");
 

--- a/contracts/referendum/referendum.cpp
+++ b/contracts/referendum/referendum.cpp
@@ -273,6 +273,8 @@ void referendum::cancel(name referendum_id, name dac_id) {
 void referendum::exec(name referendum_id, name dac_id) {
     checkDAC(dac_id);
 
+    updatestatus(referendum_id, dac_id);
+
     referenda_table referenda(get_self(), dac_id.value);
     auto            ref = referenda.require_find(referendum_id.value, "ERR:REFERENDUM_NOT_FOUND::Referendum not found");
 

--- a/contracts/referendum/referendum.hpp
+++ b/contracts/referendum/referendum.hpp
@@ -221,6 +221,8 @@ CONTRACT referendum : public contract {
     ACTION updatestatus(name referendum_id, name dac_id);
     ACTION clearconfig(name dac_id);
 
+    ACTION publresult(referendum_data ref);
+
     // Observation of stake deltas
     ACTION stakeobsv(vector<account_stake_delta> stake_deltas, name dac_id);
 

--- a/contracts/referendum/referendum.test.ts
+++ b/contracts/referendum/referendum.test.ts
@@ -60,7 +60,7 @@ let candidates: Account[];
 // let arbitrator: Account;
 let planet: Account;
 
-describe('referendum', () => {
+describe('Referendum', () => {
   before(async () => {
     shared = await SharedTestObjects.getInstance();
     referendum = shared.referendum_contract;
@@ -80,6 +80,10 @@ describe('referendum', () => {
     await configureAuths();
     await linkPermissions();
 
+    await shared.daccustodian_contract.newperiod(dacId, dacId, {
+      from: regMembers[0],
+    });
+    await sleep(6_000);
     await shared.daccustodian_contract.newperiod(dacId, dacId, {
       from: regMembers[0],
     });

--- a/contracts/referendum/referendum.test.ts
+++ b/contracts/referendum/referendum.test.ts
@@ -29,27 +29,35 @@ let user2: Account;
 let dacId = 'refdac';
 
 enum vote_type {
-  TYPE_BINDING = 0,
-  TYPE_SEMI_BINDING = 1,
-  TYPE_OPINION = 2,
-  TYPE_INVALID = 3,
+  TYPE_BINDING = 'binding',
+  TYPE_SEMI_BINDING = 'semibinding',
+  TYPE_OPINION = 'opinion',
+  // TYPE_INVALID = 3,
 }
+
 enum count_type {
-  COUNT_TOKEN = 0,
-  COUNT_ACCOUNT = 1,
+  COUNT_TOKEN = 'token',
+  COUNT_ACCOUNT = 'account',
   COUNT_INVALID = 2,
+}
+
+enum voting_type {
+  VOTE_PROP_REMOVE = 'remove',
+  VOTE_PROP_YES = 'yes',
+  VOTE_PROP_NO = 'no',
+  VOTE_PROP_ABSTAIN = 'abstain',
 }
 
 const seconds = 1;
 const minutes = 60 * seconds;
 
 let serialized_actions: any;
-let delegateeCustodian: Account;
+// let delegateeCustodian: Account;
 let regMembers: Account[];
 let candidates: Account[];
-let otherAccount: Account;
-let proposer1Account: Account;
-let arbitrator: Account;
+// let otherAccount: Account;
+// let proposer1Account: Account;
+// let arbitrator: Account;
 let planet: Account;
 
 describe('referendum', () => {
@@ -113,21 +121,21 @@ describe('referendum', () => {
           duration: 5 * minutes,
           fee: [
             {
-              key: 0,
+              key: vote_type.TYPE_BINDING,
               value: {
                 contract: shared.dac_token_contract.account.name,
                 quantity: '1.0000 REF',
               },
             },
             {
-              key: 1,
+              key: vote_type.TYPE_SEMI_BINDING,
               value: {
                 contract: shared.dac_token_contract.account.name,
                 quantity: '1.0000 REF',
               },
             },
             {
-              key: 2,
+              key: vote_type.TYPE_OPINION,
               value: {
                 contract: shared.dac_token_contract.account.name,
                 quantity: '1.0000 REF',
@@ -136,71 +144,71 @@ describe('referendum', () => {
           ],
           pass: [
             {
-              key: 0,
+              key: vote_type.TYPE_BINDING,
               value: 1000,
             },
             {
-              key: 1,
+              key: vote_type.TYPE_SEMI_BINDING,
               value: 1000,
             },
             {
-              key: 2,
+              key: vote_type.TYPE_OPINION,
               value: 1000,
             },
           ],
           quorum_token: [
             {
-              key: 0,
+              key: vote_type.TYPE_BINDING,
               value: 1000,
             },
             {
-              key: 1,
+              key: vote_type.TYPE_SEMI_BINDING,
               value: 1000,
             },
             {
-              key: 2,
+              key: vote_type.TYPE_OPINION,
               value: 1000,
             },
           ],
           quorum_account: [
             {
-              key: 0,
+              key: vote_type.TYPE_BINDING,
               value: 1000,
             },
             {
-              key: 1,
+              key: vote_type.TYPE_SEMI_BINDING,
               value: 1000,
             },
             {
-              key: 2,
+              key: vote_type.TYPE_OPINION,
               value: 1000,
             },
           ],
           allow_per_account_voting: [
             {
-              key: 0,
+              key: vote_type.TYPE_BINDING,
               value: 1,
             },
             {
-              key: 1,
+              key: vote_type.TYPE_SEMI_BINDING,
               value: 1,
             },
             {
-              key: 2,
+              key: vote_type.TYPE_OPINION,
               value: 1,
             },
           ],
           allow_vote_type: [
             {
-              key: 0,
+              key: vote_type.TYPE_BINDING,
               value: 1,
             },
             {
-              key: 1,
+              key: vote_type.TYPE_SEMI_BINDING,
               value: 1,
             },
             {
-              key: 2,
+              key: vote_type.TYPE_OPINION,
               value: 1,
             },
           ],
@@ -302,7 +310,13 @@ describe('referendum', () => {
   });
   context('vote', async () => {
     it('should work', async () => {
-      await referendum.vote(user1.name, 'ref1', 1, dacId, { from: user1 });
+      await referendum.vote(
+        user1.name,
+        'ref1',
+        voting_type.VOTE_PROP_YES,
+        dacId,
+        { from: user1 }
+      );
     });
   });
   context('exec', async () => {


### PR DESCRIPTION
Some cleanups to the referendum contract including:
* Change the enums from being numbers to being eosio::name types to be more human-readable
* Added a clean up for the votes that have been removed during the update of stake voting.
* Updated the check_transaction_authorization  internal action to stop using an internal action. 