### PR TITLE
add require_auth to referendum::voter

### DIFF
--- a/contracts/referendum/referendum.cpp
+++ b/contracts/referendum/referendum.cpp
@@ -142,7 +142,7 @@ void referendum::propose(name proposer, name referendum_id, name type_name, name
 }
 
 void referendum::vote(name voter, name referendum_id, name vote, name dac_id) {
-
+    require_auth(voter);
     checkDAC(dac_id);
     assertValidMember(voter, dac_id);
     auto dac = dacdir::dac_for_id(dac_id);


### PR DESCRIPTION
This PR add require_auth(voter) to the referendum::vote ACTION.