### PR TITLE
Updates to the DAO election process to include a configurable pending time

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -194,6 +194,10 @@ namespace eosdac {
         //     - used for pay calculations if an eary election is called and to trigger deferred `newperiod` calls.
         uint32_t periodlength = 7 * 24 * 60 * 60;
 
+        // Length of time in seconds for the pending period. This is the time between the election and when the new
+        // custodians take over.
+        uint32_t pending_period_delay = 5 * 60;
+
         // The contract will direct all payments via the service provider.
         bool should_pay_via_service_provider;
 
@@ -294,10 +298,12 @@ namespace eosdac {
             PROPERTY(uint32_t, number_active_candidates);
             PROPERTY(int64_t, total_votes_on_candidates); 
             PROPERTY(eosio::time_point_sec, lastperiodtime);
+            PROPERTY(eosio::time_point_sec, pending_period_time);
             PROPERTY(eosio::extended_asset, lockupasset); 
             PROPERTY(uint8_t, maxvotes); 
             PROPERTY(uint8_t, numelected);
             PROPERTY(uint32_t, periodlength); 
+            PROPERTY(uint32_t, pending_period_delay); 
             PROPERTY(bool, should_pay_via_service_provider);
             PROPERTY(uint32_t, initial_vote_quorum_percent); 
             PROPERTY(uint32_t, vote_quorum_percent);
@@ -410,6 +416,7 @@ namespace eosdac {
                                    time_point_sec new_time_stamp, const name dac_id, const bool from_voting);
         void modifyProxiesWeight(int64_t vote_weight, name oldProxy, name newProxy, name dac_id, bool from_voting);
         void assertPeriodTime(const dacglobals &globals);
+        void assertPendingPeriodTime(const dacglobals &globals);
         void distributeMeanPay(name internal_dac_id);
         vector<eosiosystem::permission_level_weight> get_perm_level_weights(
             const custodians_table &custodians, const name &dac_id);
@@ -424,6 +431,8 @@ namespace eosdac {
         void removeCustodian(name cust, name internal_dac_id);
         void disableCandidate(name cust, name internal_dac_id);
         void removeCandidate(name cust, name internal_dac_id);
+        void prepareCustodians(name internal_dac_id);
+        bool periodIsPending(name internal_dac_id);
         void allocateCustodians(name internal_dac_id);
         bool permissionExists(name account, name permission);
         bool _check_transaction_authorization(const char *trx_data, uint32_t trx_size, const char *pubkeys_data,

--- a/contracts/TestHelpers.ts
+++ b/contracts/TestHelpers.ts
@@ -190,6 +190,7 @@ export class SharedTestObjects {
           quantity: '30.0000 EOS',
         },
         periodlength: 5,
+        pending_period_delay: 3,
         initial_vote_quorum_percent: 31,
         vote_quorum_percent: 15,
         auth_threshold_high: 4,

--- a/contracts/daccustodian/config.cpp
+++ b/contracts/daccustodian/config.cpp
@@ -20,6 +20,9 @@ ACTION daccustodian::updateconfige(const contr_config &new_config, const name &d
     check(new_config.periodlength <= 3 * 365 * 24 * 60 * 60,
         "ERR::UPDATECONFIG_PERIOD_LENGTH::The period length cannot be longer than 3 years.");
 
+    check(new_config.pending_period_delay <= new_config.periodlength,
+        "ERR::UPDATECONFIG_PENDING_PERIOD_LENGTH::The pending period length cannot be longer than the period length.");
+
     check(new_config.initial_vote_quorum_percent < 100,
         "ERR::UPDATECONFIG_INVALID_INITIAL_VOTE_QUORUM_PERCENT::The initial vote quorum percent must be less than 100 and most likely a lot less than 100 to be achievable for the DAC.");
 
@@ -51,6 +54,7 @@ ACTION daccustodian::updateconfige(const contr_config &new_config, const name &d
     globals.set_maxvotes(new_config.maxvotes);
     globals.set_numelected(new_config.numelected);
     globals.set_periodlength(new_config.periodlength);
+    globals.set_pending_period_delay(new_config.pending_period_delay);
     globals.set_should_pay_via_service_provider(new_config.should_pay_via_service_provider);
     globals.set_initial_vote_quorum_percent(new_config.initial_vote_quorum_percent);
     globals.set_vote_quorum_percent(new_config.vote_quorum_percent);

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -71,6 +71,7 @@ describe('Daccustodian', () => {
             auth_threshold_mid: 6,
             requested_pay_max: { contract: 'sdfsdf', quantity: '12.0000 EOS' },
             periodlength: 37500,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 15,
             auth_threshold_high: 4,
@@ -101,6 +102,7 @@ describe('Daccustodian', () => {
             maxvotes: 5,
             requested_pay_max: { contract: 'sdfsdf', quantity: '12.0000 EOS' },
             periodlength: 37500,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 15,
             auth_threshold_high: 5,
@@ -132,6 +134,7 @@ describe('Daccustodian', () => {
             maxvotes: 5,
             requested_pay_max: { contract: 'sdfsdf', quantity: '12.0000 EOS' },
             periodlength: 37500,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 15,
             auth_threshold_high: 9,
@@ -155,6 +158,38 @@ describe('Daccustodian', () => {
         []
       );
     });
+    it('Should fail for pending being longer than the period length', async () => {
+      await assertEOSErrorIncludesMessage(
+        shared.daccustodian_contract.updateconfige(
+          {
+            numelected: 12,
+            maxvotes: 5,
+            requested_pay_max: { contract: 'sdfsdf', quantity: '12.0000 EOS' },
+            periodlength: 5,
+            pending_period_delay: 7,
+            initial_vote_quorum_percent: 31,
+            vote_quorum_percent: 15,
+            auth_threshold_high: 9,
+            auth_threshold_mid: 7,
+            auth_threshold_low: 8,
+            lockupasset: { contract: 'sdfsdf', quantity: '12.0000 EOS' },
+            should_pay_via_service_provider: false,
+            lockup_release_time_delay: 1233,
+            token_supply_theshold: 10000001,
+          },
+          dacId,
+          { from: shared.auth_account }
+        ),
+        'ERR::UPDATECONFIG_PENDING_PERIOD_LENGTH'
+      );
+      await assertRowsEqual(
+        shared.daccustodian_contract.dacglobalsTable({
+          scope: dacId,
+          limit: 2,
+        }),
+        []
+      );
+    });
     it('Should fail for invalid low auth threshold', async () => {
       await assertEOSErrorIncludesMessage(
         shared.daccustodian_contract.updateconfige(
@@ -163,6 +198,7 @@ describe('Daccustodian', () => {
             maxvotes: 5,
             requested_pay_max: { contract: 'sdfsdf', quantity: '12.0000 EOS' },
             periodlength: 5,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 15,
             auth_threshold_high: 9,
@@ -197,6 +233,7 @@ describe('Daccustodian', () => {
               quantity: '30.0000 EOS',
             },
             periodlength: 5,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 15,
             auth_threshold_high: 4,
@@ -227,6 +264,7 @@ describe('Daccustodian', () => {
               quantity: '30.0000 EOS',
             },
             periodlength: 5,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 15,
             auth_threshold_high: 4,
@@ -257,6 +295,7 @@ describe('Daccustodian', () => {
               quantity: '30.0000 EOS',
             },
             periodlength: 4 * 365 * 24 * 60 * 60,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 15,
             auth_threshold_high: 4,
@@ -287,6 +326,7 @@ describe('Daccustodian', () => {
               quantity: '30.0000 EOS',
             },
             periodlength: 7 * 24 * 60 * 60,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 100,
             vote_quorum_percent: 15,
             auth_threshold_high: 4,
@@ -317,6 +357,7 @@ describe('Daccustodian', () => {
               quantity: '30.0000 EOS',
             },
             periodlength: 7 * 24 * 60 * 60,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 101,
             auth_threshold_high: 4,
@@ -347,6 +388,7 @@ describe('Daccustodian', () => {
               quantity: '30.0000 EOS',
             },
             periodlength: 7 * 24 * 60 * 60,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 15,
             auth_threshold_high: 4,
@@ -376,6 +418,7 @@ describe('Daccustodian', () => {
             quantity: '30.0000 EOS',
           },
           periodlength: 5,
+          pending_period_delay: 4,
           initial_vote_quorum_percent: 31,
           vote_quorum_percent: 15,
           auth_threshold_high: 4,
@@ -446,6 +489,10 @@ describe('Daccustodian', () => {
               {
                 key: 'periodlength',
                 value: ['uint32', 5],
+              },
+              {
+                key: 'pending_period_delay',
+                value: ['uint32', 4],
               },
               {
                 key: 'requested_pay_max',
@@ -541,6 +588,7 @@ describe('Daccustodian', () => {
                   quantity: '25.0000 EOS',
                 },
                 periodlength: 5,
+                pending_period_delay: 4,
                 initial_vote_quorum_percent: 31,
                 vote_quorum_percent: 15,
                 auth_threshold_high: 4,
@@ -595,6 +643,7 @@ describe('Daccustodian', () => {
                   quantity: '25.0000 EOS',
                 },
                 periodlength: 5,
+                pending_period_delay: 4,
                 initial_vote_quorum_percent: 31,
                 vote_quorum_percent: 15,
                 auth_threshold_high: 4,
@@ -1790,6 +1839,8 @@ describe('Daccustodian', () => {
                     quantity: '23.0000 EOS',
                   },
                   periodlength: 5,
+                  pendingPeriodlength: 8,
+                  pending_period_delay: 4,
                   initial_vote_quorum_percent: 31,
                   vote_quorum_percent: 15,
                   auth_threshold_high: 4,
@@ -1832,6 +1883,37 @@ describe('Daccustodian', () => {
                 number_of_custodians
               );
             });
+            it('should not populate the custodians yet since this is the first election', async () => {
+              await assertRowCount(
+                shared.daccustodian_contract.custodians1Table({
+                  scope: dacId,
+                  limit: 20,
+                }),
+                0
+              );
+            });
+            it('should not execute new period while in pending period.', async () => {
+              await assertEOSErrorIncludesMessage(
+                shared.daccustodian_contract.newperiod(
+                  'initial new period',
+                  dacId,
+                  {
+                    from: regMembers[0], // Could be run by anyone.
+                  }
+                ),
+                'ERR::NEWPERIOD_PENDING_EARLY'
+              );
+            });
+            it('should not execute new period while in pending period.', async () => {
+              await sleep(4000);
+              await shared.daccustodian_contract.newperiod(
+                'initial new period',
+                dacId,
+                {
+                  from: regMembers[0], // Could be run by anyone.
+                }
+              );
+            });
             it('should have set socials to false', async () => {
               const actual = await get_from_dacglobals(
                 dacId,
@@ -1860,7 +1942,8 @@ describe('Daccustodian', () => {
                 keyType: 'i64',
               });
 
-              let res2 = await shared.daccustodian_contract.pendingcustsTable({
+              let pendingCusts =
+                await shared.daccustodian_contract.pendingcustsTable({
                 scope: dacId,
                 limit: 100,
                 indexPosition: 2, // bydecayed index
@@ -1882,9 +1965,8 @@ describe('Daccustodian', () => {
                 'candidates.slice(0, 5): ',
                 JSON.stringify(candidates.slice(0, 5), null, 2)
               );
-              console.log('res2.rows: ', JSON.stringify(res2.rows, null, 2));
-              chai.expect(res2.rows.length).to.equal(5);
-              chai.expect(candidates.slice(0, 5)).to.deep.equal(res2.rows);
+              // console.log('pendingCusts.rows: ', JSON.stringify(pendingCusts.rows, null, 2));
+              chai.expect(pendingCusts.rows.length).to.equal(0); // should be empty after custodians are set.
             });
             it('Custodians should not yet be paid', async () => {
               await assertRowCount(
@@ -1959,6 +2041,7 @@ describe('Daccustodian', () => {
                   quantity: '23.0000 EOS',
                 },
                 periodlength: 5,
+                pending_period_delay: 4,
                 initial_vote_quorum_percent: 31,
                 vote_quorum_percent: 15,
                 auth_threshold_high: 4,
@@ -2015,6 +2098,7 @@ describe('Daccustodian', () => {
                   quantity: '23.0000 EOS',
                 },
                 periodlength: 5,
+                pending_period_delay: 4,
                 initial_vote_quorum_percent: 31,
                 vote_quorum_percent: 15,
                 auth_threshold_high: 4,
@@ -2276,6 +2360,7 @@ describe('Daccustodian', () => {
             quantity: '0.0000 EOS',
           },
           periodlength: 5,
+          pending_period_delay: 4,
           initial_vote_quorum_percent: 31,
           vote_quorum_percent: 15,
           auth_threshold_high: 4,
@@ -3016,6 +3101,7 @@ describe('Daccustodian', () => {
               quantity: '30.0000 EOS',
             },
             periodlength: 5,
+            pending_period_delay: 4,
             initial_vote_quorum_percent: 31,
             vote_quorum_percent: 15,
             auth_threshold_high: 4,
@@ -3121,7 +3207,8 @@ describe('Daccustodian', () => {
             contract: 'eosio.token',
             quantity: '0.0000 EOS',
           },
-          periodlength: 1,
+          periodlength: 2,
+          pending_period_delay: 1,
           initial_vote_quorum_percent: 31,
           vote_quorum_percent: 15,
           auth_threshold_high: 4,
@@ -3155,7 +3242,14 @@ describe('Daccustodian', () => {
             from: regMembers[0],
           }
         );
-        await sleep(1000);
+        await sleep(2000);
+        await shared.daccustodian_contract.newperiod(
+          'initial new period',
+          dacId,
+          {
+            from: regMembers[0],
+          }
+        );
       });
       it('claimbudget should fail', async () => {
         await assertEOSErrorIncludesMessage(
@@ -3199,6 +3293,7 @@ describe('Daccustodian', () => {
           'Some money for the authority',
           { from: shared.tokenIssuer }
         );
+        await sleep(3000);
 
         await shared.daccustodian_contract.newperiod(
           'initial new period',
@@ -3207,7 +3302,14 @@ describe('Daccustodian', () => {
             from: regMembers[0],
           }
         );
-        await sleep(1000);
+        await sleep(2000);
+        await shared.daccustodian_contract.newperiod(
+          'initial new period',
+          dacId,
+          {
+            from: regMembers[0],
+          }
+        );
       });
       it('should not transfer budget', async () => {
         await assertBalanceEqual(
@@ -3308,6 +3410,15 @@ describe('Daccustodian', () => {
             'Some money for the treasury',
             { from: shared.tokenIssuer }
           );
+          await sleep(2000);
+          await shared.daccustodian_contract.newperiod(
+            'initial new period',
+            dacId,
+            {
+              from: regMembers[0],
+            }
+          );
+          await sleep(2000);
           await shared.daccustodian_contract.newperiod(
             'initial new period',
             dacId,
@@ -3440,6 +3551,15 @@ describe('Daccustodian', () => {
       let treasury_balance_before;
       let auth_balance_before;
       before(async () => {
+        await sleep(2000);
+        await shared.daccustodian_contract.newperiod(
+          'initial new period',
+          dacId,
+          {
+            from: regMembers[0],
+          }
+        );
+        await sleep(2000);
         await shared.daccustodian_contract.newperiod(
           'initial new period',
           dacId,


### PR DESCRIPTION
The elected custodians are written to a pending table before the new custodians are brought to power after the pending period and new period is called again.

BTW. The test pass when run just for the daccustodians tests.



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/86930dqqm) by [Unito](https://www.unito.io)
