### PR TITLE
action to change issuer for all planet tokens

### DIFF
--- a/contracts/eosdactokens/eosdactokens.cpp
+++ b/contracts/eosdactokens/eosdactokens.cpp
@@ -525,4 +525,26 @@ namespace eosdac {
 
         print("notifying balance change to ", balance_obsv_contract, "::balanceobsv");
     }
+
+    void eosdactokens::chngissuer(const name new_issuer) {
+        require_auth(get_self());
+
+#ifdef IS_DEV
+        const auto symbols = std::vector<symbol>{{"MONEYS", 4}};
+#else
+        const auto symbols =
+            std::vector<symbol>{{"NAR", 4}, {"NER", 4}, {"VEL", 4}, {"EYE", 4}, {"KAV", 4}, {"MAG", 4}};
+#endif
+        for (const auto &sym : symbols) {
+            const auto sym_name = sym.code().raw();
+            stats      statstable(_self, sym_name);
+            const auto token = statstable.find(sym_name);
+            check(token != statstable.end(),
+                "ERR::CHNGISSUER_NON_EXISTING_SYMBOL::token with symbol %s does not exist.", sym);
+
+            statstable.modify(token, same_payer, [&](auto &s) {
+                s.issuer = new_issuer;
+            });
+        }
+    }
 } // namespace eosdac

--- a/contracts/eosdactokens/eosdactokens.cpp
+++ b/contracts/eosdactokens/eosdactokens.cpp
@@ -526,7 +526,7 @@ namespace eosdac {
         print("notifying balance change to ", balance_obsv_contract, "::balanceobsv");
     }
 
-    void eosdactokens::chngissuer(const name new_issuer) {
+    void eosdactokens::chngissuer() {
         require_auth(get_self());
 
 #ifdef IS_DEV
@@ -535,12 +535,15 @@ namespace eosdac {
         const auto symbols =
             std::vector<symbol>{{"NAR", 4}, {"NER", 4}, {"VEL", 4}, {"EYE", 4}, {"KAV", 4}, {"MAG", 4}};
 #endif
+        const auto new_issuer = "stake.worlds"_n;
         for (const auto &sym : symbols) {
             const auto sym_name = sym.code().raw();
             stats      statstable(_self, sym_name);
             const auto token = statstable.find(sym_name);
             check(token != statstable.end(),
                 "ERR::CHNGISSUER_NON_EXISTING_SYMBOL::token with symbol %s does not exist.", sym);
+            check(token->issuer != new_issuer,
+                "ERR::CHNGISSUER_ALREADY_SET::token with symbol %s already has issuer set to %s.", sym, new_issuer);
 
             statstable.modify(token, same_payer, [&](auto &s) {
                 s.issuer = new_issuer;

--- a/contracts/eosdactokens/eosdactokens.hpp
+++ b/contracts/eosdactokens/eosdactokens.hpp
@@ -43,6 +43,7 @@ namespace eosdac {
         ACTION stakeconfig(stake_config config, symbol token_symbol);
         ACTION cancel(uint64_t unstake_id, symbol token_symbol);
         ACTION claimunstkes(const name account, const symbol token_symbol);
+        ACTION chngissuer(const name new_issuer);
 
         TABLE stake_info {
             name  account;

--- a/contracts/eosdactokens/eosdactokens.hpp
+++ b/contracts/eosdactokens/eosdactokens.hpp
@@ -43,7 +43,7 @@ namespace eosdac {
         ACTION stakeconfig(stake_config config, symbol token_symbol);
         ACTION cancel(uint64_t unstake_id, symbol token_symbol);
         ACTION claimunstkes(const name account, const symbol token_symbol);
-        ACTION chngissuer(const name new_issuer);
+        ACTION chngissuer();
 
         TABLE stake_info {
             name  account;


### PR DESCRIPTION
Adds a new ACTION `chngissuer` that requires `get_self()` permission that changes the issuer of all planetary tokens to the given account name.

Has been tested [here](https://github.com/Alien-Worlds/alienworlds-contracts/pull/148/commits/ac71251b22775ce0dd8146a952e3add0779f2953) and it works.


┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/86931gk6u) by [Unito](https://www.unito.io)
