### PR TITLE
Change the compiling step to inject the magic value 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ artifacts/compiled_contracts
 /debugging/yarn.lock
 /debugging/tables_stakevote.json
 /debugging/tables_daccustodian.json
+.magic_key_value

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "[eosDAC Smart Contracts Explained](https://eosdac.io/tools/smart-contracts-explained/)",
   "main": "index.js",
   "scripts": {
-    "build": "lamington build",
+    "build": "lamington build -DMAGIC_KEY_VALUE=$(<.magic_key_value)",
     "build-debug": "lamington build -DDEBUG",
     "build-dev": "lamington build -DIS_DEV",
     "test": "lamington test -DIS_DEV",


### PR DESCRIPTION
This is only relevant for the planet token contract.
The value is injected from a git ignored file named `.magic_key_value`



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/86936cpty) by [Unito](https://www.unito.io)
