### PR TITLE
Whitelist for daccustodian and dacpropsals

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -289,6 +289,17 @@ namespace eosdac {
 
     using candperms_table = multi_index<"candperms"_n, candperm>;
 
+    struct [[eosio::table("whitelist"), eosio::contract("daccustodian")]] whitelist {
+        name     cand;
+        uint64_t rating;
+
+        uint64_t primary_key() const {
+            return cand.value;
+        }
+    };
+
+    using whitelist_table = eosio::multi_index<"whitelist"_n, whitelist>;
+
     // clang-format off
     SINGLETON(dacglobals, daccustodian, 
             PROPERTY_OPTIONAL_TYPECASTING(uint16_t, uint32_t, budget_percentage);
@@ -315,6 +326,7 @@ namespace eosdac {
             PROPERTY(eosio::extended_asset, requested_pay_max); 
             PROPERTY(uint64_t, token_supply_theshold);
             PROPERTY(bool, maintenance_mode);
+            PROPERTY_OPTIONAL_TYPECASTING(bool, bool, requires_whitelist);
     )
     // clang-format on
 
@@ -375,6 +387,10 @@ namespace eosdac {
         ACTION setbudget(const name &dac_id, const uint16_t percentage);
         ACTION setprpbudget(const name &dac_id, const uint16_t percentage);
         ACTION unsetbudget(const name &dac_id);
+        ACTION setrequirewl(const name &dac_id, bool required);
+        ACTION addwl(name cand, uint64_t rating, name dac_id);
+        ACTION updwl(name cand, uint64_t rating, name dac_id);
+        ACTION rmvwl(name cand, name dac_id);
 
 #ifdef DEBUG
         ACTION migratestate(const name &dac_id);

--- a/contracts/TestHelpers.ts
+++ b/contracts/TestHelpers.ts
@@ -94,45 +94,58 @@ export class SharedTestObjects {
       'dacdirectory',
       'index.worlds'
     );
+    console.log('deployed index.worlds');
 
     this.daccustodian_contract = await debugPromise(
       ContractDeployer.deployWithName('daccustodian', 'daccustodian'),
       'created daccustodian'
     );
+    console.log('deployed daccustodian');
 
     this.dac_token_contract = await debugPromise(
       ContractDeployer.deployWithName('eosdactokens', 'token.worlds'),
       'created eosdactokens'
     );
+    console.log('deployed token.worlds');
+
     this.dacproposals_contract = await debugPromise(
       ContractDeployer.deployWithName('dacproposals', 'dacproposals'),
       'created dacproposals'
     );
+    console.log('deployed dacproposals');
+
     await this.dacproposals_contract.account.addCodePermission();
 
     this.dacescrow_contract = await debugPromise(
       ContractDeployer.deployWithName('dacescrow', 'dacescrow'),
       'created dacescrow'
     );
+    console.log('deployed dacescrow');
+
     this.msigworlds_contract = await debugPromise(
       ContractDeployer.deployWithName<Msigworlds>('msigworlds', 'msig.worlds'),
       'created msigworlds_contract'
     );
+    console.log('deplyed msig.worlds');
 
     this.referendum_contract = await debugPromise(
       ContractDeployer.deployWithName<Referendum>('referendum', 'referendum'),
       'created referendum_contract'
     );
+    console.log('deplyed referendum');
 
     this.stakevote_contract = await debugPromise(
       ContractDeployer.deployWithName<Stakevote>('stakevote', 'stakevote'),
       'created stakevote_contract'
     );
+    console.log('deplyed stakevote');
 
     this.atomicassets = await ContractDeployer.deployWithName<Atomicassets>(
       'atomicassets',
       'atomicassets'
     );
+    console.log('deployed atomicassets');
+
     await this.atomicassets.account.addCodePermission();
     await this.atomicassets.init({ from: this.atomicassets.account });
 

--- a/contracts/daccustodian/config.cpp
+++ b/contracts/daccustodian/config.cpp
@@ -322,3 +322,14 @@ ACTION daccustodian::unsetbudget(const name &dac_id) {
     auto globals = dacglobals{get_self(), dac_id};
     globals.unset_budget_percentage();
 }
+
+ACTION daccustodian::setrequirewl(const name &dac_id, bool required) {
+    require_auth(get_self());
+
+    auto globals = dacglobals{get_self(), dac_id};
+    if (required) {
+        globals.set_requires_whitelist(true);
+    } else {
+        globals.unset_requires_whitelist();
+    }
+}

--- a/contracts/daccustodian/registering.cpp
+++ b/contracts/daccustodian/registering.cpp
@@ -8,7 +8,7 @@ ACTION daccustodian::nominatecane(const name &cand, const asset &requestedpay, c
     assertValidMember(cand, dac_id);
     auto globals = dacglobals{get_self(), dac_id};
 
-    if (globals.maybe_get_requires_whitelist()) {
+    if (globals.maybe_get_requires_whitelist().has_value() && globals.maybe_get_requires_whitelist().value() == true) {
         whitelist_table whitelist(get_self(), dac_id.value);
         check(whitelist.find(cand.value) != whitelist.end(), "ERR::NOT_IN_WHITELIST::Candidate is not in whitelist.");
     }

--- a/contracts/dacproposals/dacproposals.hpp
+++ b/contracts/dacproposals/dacproposals.hpp
@@ -145,6 +145,17 @@ namespace eosdac {
         using arbiterwhitelist_table = eosio::multi_index<"arbwhitelist"_n, arbiter_white_list>;
         // clang-format on
 
+        struct [[eosio::table("recwl"), eosio::contract("daccustodian")]] receiver_whitelist {
+            name     receiver;
+            uint64_t rating;
+
+            uint64_t primary_key() const {
+                return receiver.value;
+            }
+        };
+
+        using rec_whitelist_table = eosio::multi_index<"recwl"_n, receiver_whitelist>;
+
         dacproposals(name receiver, name code, datastream<const char *> ds) : contract(receiver, code, ds) {}
 
         ACTION createprop(name proposer, string title, string summary, name arbiter, extended_asset proposal_pay,
@@ -176,6 +187,10 @@ namespace eosdac {
         ACTION addarbwl(name arbiter, uint64_t rating, name dac_id);
         ACTION updarbwl(name arbiter, uint64_t rating, name dac_id);
         ACTION rmvarbwl(name arbiter, name dac_id);
+
+        ACTION addrecwl(name cand, uint64_t rating, name dac_id);
+        ACTION updrecwl(name cand, uint64_t rating, name dac_id);
+        ACTION rmvrecwl(name cand, name dac_id);
 
         [[eosio::on_notify("*::transfer")]] void receive(name from, name to, asset quantity, string memo);
         ACTION                                   minduration(uint32_t new_min_proposal_duration, name dac_id);

--- a/contracts/dacproposals/dacproposals.hpp
+++ b/contracts/dacproposals/dacproposals.hpp
@@ -145,7 +145,7 @@ namespace eosdac {
         using arbiterwhitelist_table = eosio::multi_index<"arbwhitelist"_n, arbiter_white_list>;
         // clang-format on
 
-        struct [[eosio::table("recwl"), eosio::contract("daccustodian")]] receiver_whitelist {
+        struct [[eosio::table("recwl"), eosio::contract("dacproposals")]] receiver_whitelist {
             name     receiver;
             uint64_t rating;
 


### PR DESCRIPTION
Adds:
* whitelists for daccustodians for candidates
* config to indicate if a DAO requires verified candidates
* whitelist for worker proposals proposers
* management actions to add/remove/update accounts on the added whitelists

Updated tests for the new logic and ensured they pass.