### PR TITLE
Improvements to whitelist management so the adding to custodians pops off the arbiter list and viceversa.

### DIFF
--- a/contracts/dacproposals/dacproposals.hpp
+++ b/contracts/dacproposals/dacproposals.hpp
@@ -187,6 +187,8 @@ namespace eosdac {
         ACTION addarbwl(name arbiter, uint64_t rating, name dac_id);
         ACTION updarbwl(name arbiter, uint64_t rating, name dac_id);
         ACTION rmvarbwl(name arbiter, name dac_id);
+        // Same as rmvarbwl but verifies that the arbiter is not an arbiter on a live proposal
+        ACTION safermvarbwl(name arbiter, name dac_id);
 
         ACTION addrecwl(name cand, uint64_t rating, name dac_id);
         ACTION updrecwl(name cand, uint64_t rating, name dac_id);


### PR DESCRIPTION
This is intended to prevent the case where a custodian could be an arbiter at the same time on the same DAO. 
Adding to one list should pop the user off the other list unless they cannot be popped off.
* The cases where an arbiter cannot be popped off the arbiter whitelist (added to custodian whitelist) is when they are an arbiter on a proposal that is not completed or expired for a given DAO.
* A custodian cannot be popped off the custodian whitelist (added to the arbiter whitelist) if they are a registered candidate for a DAO.

This will require each of the the contract@eosio.code to be added to the `wlman` permission on each of the `dao.worlds` and `prop.worlds` contracts.

I have not updated the tests to verify the running of this code but it compiles locally.