### PR TITLE
Worker proposal changes

### DIFF
--- a/contracts/TestHelpers.ts
+++ b/contracts/TestHelpers.ts
@@ -109,7 +109,7 @@ export class SharedTestObjects {
     console.log('deployed token.worlds');
 
     this.dacproposals_contract = await debugPromise(
-      ContractDeployer.deployWithName('dacproposals', 'dacproposals'),
+      ContractDeployer.deployWithName('dacproposals', 'prop.worlds'),
       'created dacproposals'
     );
     console.log('deployed dacproposals');

--- a/contracts/TestHelpers.ts
+++ b/contracts/TestHelpers.ts
@@ -97,7 +97,7 @@ export class SharedTestObjects {
     console.log('deployed index.worlds');
 
     this.daccustodian_contract = await debugPromise(
-      ContractDeployer.deployWithName('daccustodian', 'daccustodian'),
+      ContractDeployer.deployWithName('daccustodian', 'dao.worlds'),
       'created daccustodian'
     );
     console.log('deployed daccustodian');
@@ -953,6 +953,85 @@ export class SharedTestObjects {
     const name = sb.getName();
 
     return name;
+  }
+
+  static async add_custom_permission(
+    account,
+    name,
+    parent = 'active',
+    contract = null
+  ) {
+    if (account.account) {
+      account = account.account;
+    }
+    if (contract == null) {
+      contract = account;
+    }
+    await UpdateAuth.execUpdateAuth(
+      account.active,
+      account.name,
+      name,
+      parent,
+      UpdateAuth.AuthorityToSet.forContractCode(contract)
+    );
+  }
+  static async linkauth(
+    permission_owner,
+    permission_name,
+    action_owner,
+    action_names
+  ) {
+    if (permission_owner.account) {
+      permission_owner = permission_owner.account;
+    }
+    if (action_owner.account) {
+      action_owner = action_owner.account;
+    }
+    if (!Array.isArray(action_names)) {
+      action_names = [action_names];
+    }
+    for (const action_name of action_names) {
+      await UpdateAuth.execLinkAuth(
+        permission_owner.active,
+        permission_owner.name,
+        action_owner.name,
+        action_name,
+        permission_name
+      );
+    }
+  }
+  static async add_custom_permission_and_link(
+    permission_owner,
+    permission_name,
+    action_owner,
+    action_names,
+    contract = null
+  ) {
+    await SharedTestObjects.add_custom_permission(
+      permission_owner,
+      permission_name,
+      'active',
+      contract
+    );
+
+    try {
+      await SharedTestObjects.linkauth(
+        permission_owner,
+        permission_name,
+        action_owner,
+        action_names
+      );
+    } catch (e) {
+      if (
+        e.message.includes(
+          'Attempting to update required authority, but new requirement is same as old'
+        )
+      ) {
+        console.log('Ignoring error: ', e.message);
+      } else {
+        throw e;
+      }
+    }
   }
 }
 

--- a/contracts/daccustodian/daccustodian.test.ts
+++ b/contracts/daccustodian/daccustodian.test.ts
@@ -48,6 +48,14 @@ describe('Daccustodian', () => {
     await sleep(20000);
     shared = await SharedTestObjects.getInstance();
     somebody = await AccountManager.createAccount();
+
+    await SharedTestObjects.add_custom_permission_and_link(
+      shared.dacproposals_contract.account,
+      'wlman',
+      shared.dacproposals_contract.account,
+      'safermvarbwl',
+      shared.daccustodian_contract.account
+    );
   });
 
   context('fillstate', async () => {
@@ -3923,7 +3931,7 @@ describe('Daccustodian', () => {
       });
     });
     context('claimbudget when prop budget percentage is set', async () => {
-      const dacId = 'propdac';
+      const dacId = 'propdax';
       let expected_transfer_amount;
       let treasury_balance_before;
       let prop_funds_balance_before;
@@ -3931,12 +3939,12 @@ describe('Daccustodian', () => {
       before(async () => {
         console.log('Ohai 1');
         prop_funds_account = await AccountManager.createAccount('propfunds');
-        await shared.initDac(dacId, '4,PROPDAC', '1000000.0000 PROPDAC');
+        await shared.initDac(dacId, '4,PROPDAX', '1000000.0000 PROPDAX');
         console.log('Ohai 2');
-        await shared.updateconfig(dacId, '12.0000 PROPDAC');
+        await shared.updateconfig(dacId, '12.0000 PROPDAX');
         await shared.dac_token_contract.stakeconfig(
           { enabled: true, min_stake_time: 1233, max_stake_time: 1500 },
-          '4,PROPDAC',
+          '4,PROPDAX',
           { from: shared.auth_account }
         );
 
@@ -3972,11 +3980,11 @@ describe('Daccustodian', () => {
         );
         console.log('Ohai 3');
 
-        regMembers = await shared.getRegMembers(dacId, '20000.0000 PROPDAC');
+        regMembers = await shared.getRegMembers(dacId, '20000.0000 PROPDAX');
         console.log('Ohai 4');
         candidates = await shared.getStakeObservedCandidates(
           dacId,
-          '12.0000 PROPDAC'
+          '12.0000 PROPDAX'
         );
         console.log('Ohai 5');
         await shared.voteForCustodians(regMembers, candidates, dacId);

--- a/contracts/dacescrow/dacescrow.cpp
+++ b/contracts/dacescrow/dacescrow.cpp
@@ -87,14 +87,13 @@ namespace eosdac {
         if (esc_itr->arb == approver) {
             check(esc_itr->disputed,
                 "ERR::ESCROW_IS_NOT_LOCKED::This escrow is not locked. It can only be approved/disapproved by the arbiter while it is locked.");
-            pay_arbiter(esc_itr);
         } else if (esc_itr->sender == approver) {
             check(!esc_itr->disputed,
                 "ERR::ESCROW_DISPUTED::This escrow is locked and can only be approved/disapproved by the arbiter.");
-            refund_arbiter_pay(esc_itr);
         } else {
             check(false, "ERR::ESCROW_NOT_ALLOWED_TO_APPROVE::Only the arbiter or sender can approve an escrow.");
         }
+        pay_arbiter(esc_itr);
 
         // send funds to the receiver
         eosio::action(eosio::permission_level{_self, "active"_n}, esc_itr->receiver_pay.contract, "transfer"_n,
@@ -199,11 +198,4 @@ namespace eosdac {
         }
     }
 
-    void dacescrow::refund_arbiter_pay(const escrows_table::const_iterator esc_itr) {
-        if (esc_itr->arbiter_pay.quantity.amount > 0) {
-            eosio::action(eosio::permission_level{_self, "active"_n}, esc_itr->arbiter_pay.contract, "transfer"_n,
-                make_tuple(_self, esc_itr->sender, esc_itr->arbiter_pay.quantity, esc_itr->memo))
-                .send();
-        }
-    }
 } // namespace eosdac

--- a/contracts/dacescrow/dacescrow.hpp
+++ b/contracts/dacescrow/dacescrow.hpp
@@ -90,6 +90,5 @@ namespace eosdac {
 
       private:
         void pay_arbiter(const escrows_table::const_iterator esc_itr);
-        void refund_arbiter_pay(const escrows_table::const_iterator esc_itr);
     };
 } // namespace eosdac

--- a/contracts/dacproposals/dacproposals.hpp
+++ b/contracts/dacproposals/dacproposals.hpp
@@ -30,6 +30,7 @@ namespace eosdac {
     static constexpr eosio::name STATE_HAS_ENOUGH_FIN_VOTES{"apprfinvtes"};
     static constexpr eosio::name STATE_EXPIRED{"expired"};
     static constexpr eosio::name STATE_DISPUTED{"indispute"};
+    static constexpr eosio::name STATE_COMPLETED{"completed"};
 
     CONTRACT dacproposals : public contract {
         enum VoteTypePublic : uint64_t {
@@ -57,7 +58,8 @@ namespace eosdac {
             ProposalStateHas_enough_approvals_votes = STATE_HAS_ENOUGH_APP_VOTES.value,
             ProposalStateHas_enough_finalize_votes  = STATE_HAS_ENOUGH_FIN_VOTES.value,
             ProposalStateExpired                    = STATE_EXPIRED.value,
-            ProposalStateInDispute                  = STATE_DISPUTED.value
+            ProposalStateInDispute                  = STATE_DISPUTED.value,
+            ProposalStateCompleted                  = STATE_COMPLETED.value
         };
 
       public:
@@ -181,6 +183,7 @@ namespace eosdac {
         ACTION updateconfig(config new_config, name dac_id);
         // ACTION clearconfig(name dac_id);
         ACTION clearexpprop(name proposal_id, name dac_id);
+        ACTION rmvcompelted(name proposal_id, name dac_id);
         ACTION updpropvotes(name proposal_id, name dac_id);
         ACTION setpropfee(extended_asset new_proposal_fee, name dac_id);
         ACTION refund(name account);

--- a/contracts/dacproposals/dacproposals.hpp
+++ b/contracts/dacproposals/dacproposals.hpp
@@ -187,6 +187,8 @@ namespace eosdac {
         ACTION addarbwl(name arbiter, uint64_t rating, name dac_id);
         ACTION updarbwl(name arbiter, uint64_t rating, name dac_id);
         ACTION rmvarbwl(name arbiter, name dac_id);
+        // Same as rmvarbwl but verifies that the arbiter is not an arbiter on a live proposal
+        ACTION safermvarbwl(name arbiter, name dac_id);
 
         ACTION addrecwl(name cand, uint64_t rating, name dac_id);
         ACTION updrecwl(name cand, uint64_t rating, name dac_id);

--- a/contracts/dacproposals/dacproposals.hpp
+++ b/contracts/dacproposals/dacproposals.hpp
@@ -183,7 +183,7 @@ namespace eosdac {
         ACTION updateconfig(config new_config, name dac_id);
         // ACTION clearconfig(name dac_id);
         ACTION clearexpprop(name proposal_id, name dac_id);
-        ACTION rmvcompelted(name proposal_id, name dac_id);
+        ACTION rmvcompleted(name proposal_id, name dac_id);
         ACTION updpropvotes(name proposal_id, name dac_id);
         ACTION setpropfee(extended_asset new_proposal_fee, name dac_id);
         ACTION refund(name account);

--- a/contracts/dacproposals/dacproposals.test.ts
+++ b/contracts/dacproposals/dacproposals.test.ts
@@ -60,6 +60,7 @@ describe('Dacproposals', () => {
 
     planet = await AccountManager.createAccount('propplanet');
 
+    await setup_permissions();
     await setup_planet();
 
     await shared.initDac(dacId, '4,PROPDAC', '1000000.0000 PROPDAC', {
@@ -68,7 +69,7 @@ describe('Dacproposals', () => {
     await shared.updateconfig(dacId, '12.0000 PROPDAC');
     eosiotoken = await ContractLoader.at('eosio.token');
     await shared.dac_token_contract.stakeconfig(
-      { enabled: true, min_stake_time: 5, max_stake_time: 20 },
+      { enabled: true, min_stake_time: 1233, max_stake_time: 20 },
       '4,PROPDAC',
       { from: shared.auth_account }
     );
@@ -3377,4 +3378,16 @@ async function setup_planet() {
     'voteprop',
     'one'
   );
+}
+
+async function setup_permissions() {
+  console.log('Ohai setup_permissions');
+  await SharedTestObjects.add_custom_permission_and_link(
+    shared.daccustodian_contract.account,
+    'wlman',
+    shared.daccustodian_contract.account,
+    'rmvwl',
+    shared.dacproposals_contract.account
+  );
+  console.log('DONE.');
 }

--- a/contracts/dacproposals/dacproposals.test.ts
+++ b/contracts/dacproposals/dacproposals.test.ts
@@ -3416,4 +3416,11 @@ async function setup_permissions() {
     'rmvwl',
     shared.dacproposals_contract.account
   );
+  await SharedTestObjects.add_custom_permission_and_link(
+    shared.dacproposals_contract.account,
+    'wlman',
+    shared.dacproposals_contract.account,
+    'safermvarbwl',
+    shared.daccustodian_contract.account
+  );
 }

--- a/contracts/referendum/referendum.test.ts
+++ b/contracts/referendum/referendum.test.ts
@@ -518,7 +518,7 @@ async function setup_token() {
     { from: shared.tokenIssuer }
   );
   await shared.dac_token_contract.stakeconfig(
-    { enabled: true, min_stake_time: 5, max_stake_time: 20 },
+    { enabled: true, min_stake_time: 1233, max_stake_time: 20 },
     '4,REF',
     { from: shared.auth_account }
   );

--- a/contracts/safemath/safemath.test.ts
+++ b/contracts/safemath/safemath.test.ts
@@ -20,10 +20,7 @@ let contract;
 
 describe('Safemath', () => {
   before(async () => {
-    contract = await ContractDeployer.deployWithName(
-      'contracts/safemath/safemath',
-      'safemath'
-    );
+    contract = await ContractDeployer.deployWithName('safemath', 'safemath');
   });
   it('testuint should work', async () => {
     await contract.testuint();

--- a/contracts/stakevote/stakevote.test.ts
+++ b/contracts/stakevote/stakevote.test.ts
@@ -285,6 +285,7 @@ describe('Stakevote', () => {
                   },
                   should_pay_via_service_provider: false,
                   lockup_release_time_delay: 1233,
+                  pending_period_delay: 4,
                 },
                 dacId,
                 { from: shared.auth_account }


### PR DESCRIPTION
These changes are small changes to the worker proposal flow after reviews with the UI.
* Arbiters should be paid for both approved and disputed proposals (previously it was only disputed ones)
* When a proposal is completed it should not be removed immediately so that it can still be seen the UI
* Added an action to remove completed proposals at a later time.
* Added Completed state for proposals.

Sorry, I have not updated the tests for this change.