### PR TITLE
Change claim budget to linear calc style

### DIFF
--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -388,6 +388,8 @@ namespace eosdac {
         ACTION settokensup(const uint64_t &token_supply_theshold, const name &dac_id);
         ACTION setbudget(const name &dac_id, const uint16_t percentage);
         ACTION setprpbudget(const name &dac_id, const uint16_t percentage);
+        ACTION setprpbudga(const name &dac_id, const asset &amount);
+        ACTION setspendbudg(const name &dac_id, const asset &amount);
         ACTION unsetbudget(const name &dac_id);
         ACTION setrequirewl(const name &dac_id, bool required);
         ACTION addwl(name cand, uint64_t rating, name dac_id);

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -302,7 +302,7 @@ namespace eosdac {
 
     // clang-format off
     SINGLETON(dacglobals, daccustodian, 
-            PROPERTY_OPTIONAL_TYPECASTING(uint16_t, uint32_t, budget_percentage);
+            PROPERTY_OPTIONAL_TYPECASTING(uint16_t, uint32_t, budget_percentage); // No longer needed. Use prop_budget_percentage and remaining budget is derived from the total balance.
             PROPERTY_OPTIONAL_TYPECASTING(uint16_t, uint32_t, prop_budget_percentage);
             PROPERTY(time_point_sec, lastclaimbudgettime); 
             PROPERTY(int64_t, total_weight_of_votes);
@@ -327,6 +327,8 @@ namespace eosdac {
             PROPERTY(uint64_t, token_supply_theshold);
             PROPERTY(bool, maintenance_mode);
             PROPERTY_OPTIONAL_TYPECASTING(bool, bool, requires_whitelist);
+            PROPERTY_OPTIONAL_TYPECASTING(asset, asset, prop_budget_amount);
+            PROPERTY_OPTIONAL_TYPECASTING(asset, asset, spendings_budget_amount);
     )
     // clang-format on
 
@@ -476,7 +478,6 @@ namespace eosdac {
         void             validateUnstake(name code, name cand, name dac_id);
         void validateUnstakeAmount(const name &code, const name &cand, const asset &unstake_amount, const name &dac_id);
         void validateMinStake(name account, name dac_id);
-        uint16_t       get_budget_percentage(const name &dac_id, const dacglobals &globals);
         time_point_sec calc_avg_vote_time(const candidate &cand);
         void update_number_of_votes(const vector<name> &oldvotes, const vector<name> &newvotes, const name &dac_id);
 

--- a/contracts/daccustodian/config.cpp
+++ b/contracts/daccustodian/config.cpp
@@ -12,8 +12,8 @@ ACTION daccustodian::updateconfige(const contr_config &new_config, const name &d
     require_auth(get_self());
 #endif
 
-    check(new_config.numelected <= 67,
-        "ERR::UPDATECONFIG_INVALID_NUM_ELECTED::The number of elected custodians must be <= 67");
+    check(new_config.numelected <= 21,
+        "ERR::UPDATECONFIG_INVALID_NUM_ELECTED::The number of elected custodians must be <= 21");
     check(new_config.maxvotes <= new_config.numelected,
         "ERR::UPDATECONFIG_INVALID_MAX_VOTES::The number of max votes must be less than the number of elected candidates.");
 
@@ -111,7 +111,7 @@ ACTION daccustodian::setnumelect(const uint8_t &numelected, const name &dac_id) 
 
     auto globals = dacglobals{get_self(), dac_id};
 
-    check(numelected <= 67, "ERR::SETNUMELECT_INVALID_VALUE::The number of elected candidates must be <= 67");
+    check(numelected <= 21, "ERR::SETNUMELECT_INVALID_VALUE::The number of elected candidates must be <= 21");
     check(numelected > 0, "ERR::SETNUMELECT_INVALID_VALUE::Number of elected candidates must be greater than zero.");
     check(numelected > 2 * globals.get_maxvotes(),
         "ERR::SETNUMELECT_LESS_THAN_MAXVOTES::Number of elected candidates cannot be less than max votes.");

--- a/contracts/daccustodian/config.cpp
+++ b/contracts/daccustodian/config.cpp
@@ -316,6 +316,20 @@ ACTION daccustodian::setprpbudget(const name &dac_id, const uint16_t percentage)
     globals.set_prop_budget_percentage(percentage);
 }
 
+ACTION daccustodian::setprpbudga(const name &dac_id, const asset &amount) {
+    require_auth(get_self());
+
+    auto globals = dacglobals{get_self(), dac_id};
+    globals.set_prop_budget_amount(amount);
+}
+
+ACTION daccustodian::setspendbudg(const name &dac_id, const asset &amount) {
+    require_auth(get_self());
+
+    auto globals = dacglobals{get_self(), dac_id};
+    globals.set_spendings_budget_amount(amount);
+}
+
 ACTION daccustodian::unsetbudget(const name &dac_id) {
     require_auth(get_self());
 

--- a/contracts/daccustodian/newperiod_components.cpp
+++ b/contracts/daccustodian/newperiod_components.cpp
@@ -265,13 +265,11 @@ ACTION daccustodian::claimbudget(const name &dac_id) {
                 .send();
 
             running_treasury_balance -= spending_amount_to_transfer;
-        } else {
-            check(false, "ERR::CLAIMBUDGET_SPENDINGS_RECIPIENT_NOT_FOUND::Spendings recipient not found. dac_id: %s",
-                dac_id);
         }
-
     } else { // If there is not enough in the treasury to cover the budget amounts, distribute the treasury balance
              // based on the budget percentage
+
+        check(false, "Config not set correctly for claim budgets. dac_id: %s", dac_id);
         const auto prop_budget_percentage = globals.maybe_get_prop_budget_percentage();
 
         if (!prop_budget_percentage.has_value()) {


### PR DESCRIPTION
Changes to the claim budget action:
* The amount claimed is based on a configured amount if there is sufficient balance for the claim amount
* Otherwise distribute a configured percentage to the worker proposal funds account
* And send the remaining balance to the spending account.

This will have the effect of leaving the spending percentage setting redundant.

Also, there is a small change to the max number of custodians allowed in the config changes.