### PR TITLE
Prevent daos change wp config

### DIFF
--- a/contracts/dacproposals/dacproposals.cpp
+++ b/contracts/dacproposals/dacproposals.cpp
@@ -438,8 +438,9 @@ namespace eosdac {
 
     ACTION dacproposals::updateconfig(config new_config, name dac_id) {
 
-        auto auth_account = dacdir::dac_for_id(dac_id).owner;
-        require_auth(auth_account);
+        // auto auth_account = dacdir::dac_for_id(dac_id).owner;
+        // require_auth(auth_account);
+        require_auth(get_self());
         auto current_configs = configs{get_self(), dac_id};
         current_configs.set_proposal_threshold(new_config.proposal_threshold);
         current_configs.set_finalize_threshold(new_config.finalize_threshold);

--- a/contracts/dacproposals/dacproposals.test.ts
+++ b/contracts/dacproposals/dacproposals.test.ts
@@ -187,7 +187,7 @@ describe('Dacproposals', () => {
             min_proposal_duration: 0,
           },
           dacId,
-          { from: shared.auth_account }
+          { from: shared.dacproposals_contract.account }
         );
       });
       it('should have correct config in config table', async () => {
@@ -1543,7 +1543,7 @@ describe('Dacproposals', () => {
             min_proposal_duration: 0,
           },
           dacId,
-          { from: shared.auth_account }
+          { from: shared.dacproposals_contract.account }
         );
         await shared.dacproposals_contract.createprop(
           proposer1Account.name,
@@ -2045,7 +2045,7 @@ describe('Dacproposals', () => {
             min_proposal_duration: 0,
           },
           dacId,
-          { from: shared.auth_account }
+          { from: shared.dacproposals_contract.account }
         );
         await shared.dacproposals_contract.createprop(
           proposer1Account.name,
@@ -2353,7 +2353,7 @@ describe('Dacproposals', () => {
             min_proposal_duration: 0,
           },
           dacId,
-          { from: shared.auth_account }
+          { from: shared.dacproposals_contract.account }
         );
         await shared.dacproposals_contract.createprop(
           proposer1Account.name,
@@ -2631,7 +2631,7 @@ describe('Dacproposals', () => {
           min_proposal_duration: 0,
         },
         dacId,
-        { from: shared.auth_account }
+        { from: shared.dacproposals_contract.account }
       );
       await shared.dacproposals_contract.createprop(
         proposer1Account.name,
@@ -2805,7 +2805,7 @@ describe('Dacproposals', () => {
           min_proposal_duration: 0,
         },
         dacId,
-        { from: shared.auth_account }
+        { from: shared.dacproposals_contract.account }
       );
       await shared.dacproposals_contract.createprop(
         proposer1Account.name,
@@ -2921,7 +2921,7 @@ describe('Dacproposals', () => {
               min_proposal_duration: 0,
             },
             dacId,
-            { from: shared.auth_account }
+            { from: shared.dacproposals_contract.account }
           );
           await shared.dacproposals_contract.createprop(
             proposer1Account.name,


### PR DESCRIPTION
Should be a simple change to prevent the DAOs changing their own WP config.

I've updated the tests but I got an error when trying to run the tests `access violation`. Could be a local issue...