### PR TITLE
add procedure and scripts to safely rebuild vote weights

### DIFF
--- a/check_proxy_votes.sh
+++ b/check_proxy_votes.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# check_proxy_votes.sh
+# -----------------------------------------------------------------------------
+# Quick helper to inspect whether any proxy-voting activity exists for a given
+# DAC on-chain.
+#
+# Usage:
+#   ./check_proxy_votes.sh <dac_id> [--url https://wax.greymass.com] \
+#                          [--contract daccustodian]
+#
+# Arguments:
+#   dac_id            The DAC id used as the table scope (e.g. alien.world).
+#
+# Options (all optional):
+#   --url      EOSIO HTTP endpoint (default: https://wax.greymass.com)
+#   --contract Account that hosts the daccustodian contract (default: daccustodian)
+#
+# Requirements:
+#   * cleos must be installed and on your PATH.
+#   * jq (https://stedolan.github.io/jq/) for JSON processing.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+API_URL="https://wax.greymass.com"
+CONTRACT="dao.worlds"
+DACDIR_ACC="index.worlds"
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url)
+      API_URL="$2"; shift; shift;;
+    --contract)
+      CONTRACT="$2"; shift; shift;;
+    --dacdir)
+      DACDIR_ACC="$2"; shift; shift;;
+    -h|--help)
+      sed -n '2,40p' "$0"; exit 0;;
+    *)
+      POSITIONAL+=("$1"); shift;;
+  esac
+done
+
+# Fetch list of DAC IDs from dacdirectory
+echo "Fetching DAC IDs from directory at $DACDIR_ACC ..." >&2
+
+DAC_IDS=$(cleos -u "$API_URL" get table "$DACDIR_ACC" "$DACDIR_ACC" dacs --limit 1000 \
+            | jq -r '.rows[].dac_id')
+
+if [[ -z "$DAC_IDS" ]]; then
+  echo "No DAC IDs found in directory." >&2
+  exit 1
+fi
+
+###########################################################################
+# Iterate over all DAC IDs                                                #
+###########################################################################
+
+for DAC_ID in $DAC_IDS; do
+  echo -e "\n==================== DAC: $DAC_ID ===================="
+
+  ###########################################################################
+  # 1. Check registered proxies                                             #
+  ###########################################################################
+
+  echo "\n---- Registered proxies (table: proxies) ----"
+  cleos -u "$API_URL" get table "$CONTRACT" "$DAC_ID" proxies --limit 1000 | jq '.rows'
+
+  ###########################################################################
+  # 2. Check votes that delegate to a proxy                                 #
+  ###########################################################################
+
+  echo "\n---- Votes delegating to a proxy (table: votes) ----"
+  cleos -u "$API_URL" get table "$CONTRACT" "$DAC_ID" votes --limit 10000 | \
+    jq '.rows[] | select(.proxy != null and .proxy != "")'
+done
+
+echo "\nDone." 

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -401,6 +401,10 @@ namespace eosdac {
         ACTION resetstate(const name &dac_id);
         ACTION clearcands(const name &dac_id);
         ACTION clearcusts(const name &dac_id);
+        // Remove all votes that delegate to a proxy for the given DAC
+        ACTION clrprxvotes(const name &dac_id);
+        // Erase all registered proxy records for the given DAC
+        ACTION clrproxies(const name &dac_id);
         ACTION maintenance(const bool maintenance);
 #endif
 

--- a/contract-shared-headers/daccustodian_shared.hpp
+++ b/contract-shared-headers/daccustodian_shared.hpp
@@ -405,6 +405,8 @@ namespace eosdac {
         ACTION clrprxvotes(const name &dac_id);
         // Erase all registered proxy records for the given DAC
         ACTION clrproxies(const name &dac_id);
+        // Clean up orphaned votes - removes candidate references that no longer exist in candidates table
+        ACTION cleanorphans(const name &dac_id, name from, name to);
         ACTION maintenance(const bool maintenance);
 #endif
 

--- a/contracts/daccustodian/debug.cpp
+++ b/contracts/daccustodian/debug.cpp
@@ -82,3 +82,34 @@ void daccustodian::maintenance(const bool maintenance) {
     auto globals = dacglobals{get_self(), get_self()};
     globals.set_maintenance_mode(maintenance);
 }
+
+// -------------------------------------------------------------------------------------------------
+//  DEBUG helpers for removing proxy-related data
+// -------------------------------------------------------------------------------------------------
+
+void daccustodian::clrprxvotes(const name &dac_id) {
+    // Only contract account itself can run destructive maintenance helpers.
+    require_auth(get_self());
+
+    check(maintenance_mode(), "ERR::NOT_MAINTENANCE_MODE::Must enable maintenance mode before running clrprxvotes");
+
+    votes_table votes_cast_by_members(_self, dac_id.value);
+
+    auto vote_itr = votes_cast_by_members.begin();
+    while (vote_itr != votes_cast_by_members.end()) {
+        vote_itr = votes_cast_by_members.erase(vote_itr);
+    }
+}
+
+void daccustodian::clrproxies(const name &dac_id) {
+    require_auth(get_self());
+
+    check(maintenance_mode(), "ERR::NOT_MAINTENANCE_MODE::Must enable maintenance mode before running clrproxies");
+
+    proxies_table proxies(_self, dac_id.value);
+
+    auto proxy_itr = proxies.begin();
+    while (proxy_itr != proxies.end()) {
+        proxy_itr = proxies.erase(proxy_itr);
+    }
+}

--- a/contracts/daccustodian/debug.cpp
+++ b/contracts/daccustodian/debug.cpp
@@ -1,7 +1,7 @@
 
 void daccustodian::resetvotes(const name &voter, const name &dac_id) {
     require_auth(get_self());
-
+    check(maintenance_mode(), "ERR::NOT_MAINTENANCE_MODE::Must enable maintenance mode before running resetvotes");
     votes_table votes_cast_by_members(_self, dac_id.value);
     auto        existingVote = votes_cast_by_members.find(voter.value);
 
@@ -10,6 +10,7 @@ void daccustodian::resetvotes(const name &voter, const name &dac_id) {
 
 void daccustodian::collectvotes(const name &dac_id, name from, name to) {
     require_auth(get_self());
+    check(maintenance_mode(), "ERR::NOT_MAINTENANCE_MODE::Must enable maintenance mode before running collectvotes");
 
     votes_table votes_cast_by_members(_self, dac_id.value);
     auto        vote_ittr = votes_cast_by_members.lower_bound(from.value);
@@ -25,6 +26,8 @@ void daccustodian::collectvotes(const name &dac_id, name from, name to) {
 
 void daccustodian::resetstate(const name &dac_id) {
     require_auth(get_self());
+    check(maintenance_mode(), "ERR::NOT_MAINTENANCE_MODE::Must enable maintenance mode before running resetstate");
+
     auto currentState = dacglobals{get_self(), dac_id};
 
     currentState.set_total_weight_of_votes(0);
@@ -35,7 +38,7 @@ void daccustodian::resetstate(const name &dac_id) {
 
 void daccustodian::resetcands(const name &dac_id) {
     require_auth(get_self());
-
+    check(maintenance_mode(), "ERR::NOT_MAINTENANCE_MODE::Must enable maintenance mode before running resetcands");
     candidates_table candidates(_self, dac_id.value);
     auto             cand = candidates.begin();
 
@@ -56,6 +59,7 @@ void daccustodian::resetcands(const name &dac_id) {
 void daccustodian::clearcands(const name &dac_id) {
     require_auth(get_self());
 
+    check(maintenance_mode(), "ERR::NOT_MAINTENANCE_MODE::Must enable maintenance mode before running clearcands");
     candidates_table candidates(_self, dac_id.value);
     auto             cand = candidates.begin();
 
@@ -66,6 +70,8 @@ void daccustodian::clearcands(const name &dac_id) {
 
 void daccustodian::clearcusts(const name &dac_id) {
     require_auth(get_self());
+
+    check(maintenance_mode(), "ERR::NOT_MAINTENANCE_MODE::Must enable maintenance mode before running clearcusts");
 
     custodians_table custodians(_self, dac_id.value);
 
@@ -97,7 +103,11 @@ void daccustodian::clrprxvotes(const name &dac_id) {
 
     auto vote_itr = votes_cast_by_members.begin();
     while (vote_itr != votes_cast_by_members.end()) {
-        vote_itr = votes_cast_by_members.erase(vote_itr);
+        if (vote_itr->proxy.value != 0) {
+            vote_itr = votes_cast_by_members.erase(vote_itr);
+        } else {
+            vote_itr++;
+        }
     }
 }
 

--- a/contracts/daccustodian/debug.cpp
+++ b/contracts/daccustodian/debug.cpp
@@ -15,13 +15,13 @@ void daccustodian::collectvotes(const name &dac_id, name from, name to) {
     votes_table votes_cast_by_members(_self, dac_id.value);
     auto        vote_ittr = votes_cast_by_members.lower_bound(from.value);
 
-    while (vote_ittr != votes_cast_by_members.end() && vote_ittr->voter != to) {
+    do {
         update_number_of_votes({}, vote_ittr->candidates, dac_id);
         const auto [vote_weight, vote_weight_quorum] = get_vote_weight(vote_ittr->voter, dac_id);
         modifyVoteWeights({vote_ittr->voter, vote_weight, vote_weight_quorum}, {}, {}, vote_ittr->candidates,
             vote_ittr->vote_time_stamp, dac_id, true);
         vote_ittr++;
-    }
+    } while (vote_ittr != votes_cast_by_members.end() && vote_ittr->voter != to);
 }
 
 void daccustodian::resetstate(const name &dac_id) {

--- a/contracts/daccustodian/registering.cpp
+++ b/contracts/daccustodian/registering.cpp
@@ -218,9 +218,7 @@ void daccustodian::disableCandidate(name cand, name dac_id) {
 }
 
 ACTION daccustodian::regproxy(const name &proxy_member, const name &dac_id) {
-#ifndef IS_DEV
     check(false, "proxy voting not yet enabled.");
-#endif
     require_auth(proxy_member);
     assertValidMember(proxy_member, dac_id);
 

--- a/debugging/check_orphaned_votes.js
+++ b/debugging/check_orphaned_votes.js
@@ -1,0 +1,267 @@
+/* eslint-env node */
+const { TableFetcher } = require('eosio-helpers');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+dayjs.extend(utc);
+
+// Configuration
+const ENDPOINT = 'https://wax.greymass.com';
+const DAO_CONTRACT = 'dao.worlds';
+const MAX = 2 ** 32;
+
+// Global state
+const dac_data = {}; // dac_id -> { votes, candidates }
+const orphaned_votes = {}; // dac_id -> Array of orphaned vote records
+
+/**
+ * Fetch all DAC IDs from the DAC directory
+ */
+async function fetch_dac_ids() {
+const dacs = await TableFetcher({
+    codeContract: 'index.worlds',
+    batch_size: 100,
+    endpoint: ENDPOINT,
+    limit: MAX,
+    scope: 'index.worlds',
+    table: 'dacs',
+});
+
+return dacs.map(dac => dac.dac_id);
+
+}
+
+/**
+ * Fetch votes and candidates tables for a specific DAC
+ */
+async function fetch_dac_tables(dac_id) {
+  console.log(`Fetching tables for DAC: ${dac_id}`);
+  
+  try {
+    const [votes, candidates] = await Promise.all([
+      TableFetcher({
+        codeContract: DAO_CONTRACT,
+        batch_size: 100,
+        endpoint: ENDPOINT,
+        limit: MAX,
+        scope: dac_id,
+        table: 'votes',
+      }),
+      TableFetcher({
+        codeContract: DAO_CONTRACT,
+        batch_size: 100,
+        endpoint: ENDPOINT,
+        limit: MAX,
+        scope: dac_id,
+        table: 'candidates',
+      })
+    ]);
+
+    return { votes, candidates };
+  } catch (error) {
+    console.error(`Error fetching tables for DAC ${dac_id}:`, error.message);
+    return { votes: [], candidates: [] };
+  }
+}
+
+/**
+ * Check for orphaned votes in a specific DAC
+ */
+function check_orphaned_votes(dac_id) {
+  const { votes, candidates } = dac_data[dac_id];
+  
+  if (!votes || !candidates) {
+    console.log(`No data available for DAC: ${dac_id}`);
+    return;
+  }
+
+  console.log(`\nChecking DAC: ${dac_id}`);
+  console.log(`- Total votes: ${votes.length}`);
+  console.log(`- Total candidates: ${candidates.length}`);
+
+  // Create a set of existing candidate names for fast lookup
+  const existing_candidates = new Set(candidates.map(c => c.candidate_name));
+  
+  let orphaned_count = 0;
+  let total_orphaned_references = 0;
+  
+  orphaned_votes[dac_id] = [];
+
+  // Check each vote record
+  for (const vote of votes) {
+    const orphaned_candidates = [];
+    
+    // Check each candidate in the vote
+    for (const candidate_name of vote.candidates) {
+      if (!existing_candidates.has(candidate_name)) {
+        orphaned_candidates.push(candidate_name);
+        total_orphaned_references++;
+      }
+    }
+    
+    // If this vote has orphaned candidates, record it
+    if (orphaned_candidates.length > 0) {
+      orphaned_count++;
+      orphaned_votes[dac_id].push({
+        voter: vote.voter,
+        vote_time_stamp: vote.vote_time_stamp,
+        vote_count: vote.vote_count,
+        total_candidates: vote.candidates.length,
+        orphaned_candidates: orphaned_candidates,
+        valid_candidates: vote.candidates.filter(c => existing_candidates.has(c)),
+        full_vote_record: vote
+      });
+    }
+  }
+
+  if (orphaned_count > 0) {
+    console.log(`\n🚨 ORPHANED VOTES DETECTED FOR DAC: ${dac_id}`);
+    console.log(`- Votes with orphaned candidates: ${orphaned_count}/${votes.length}`);
+    console.log(`- Total orphaned candidate references: ${total_orphaned_references}`);
+    console.log(`- Percentage of affected votes: ${((orphaned_count / votes.length) * 100).toFixed(2)}%`);
+  } else {
+    console.log(`✅ No orphaned votes found for DAC: ${dac_id}`);
+  }
+}
+
+/**
+ * Print detailed report for orphaned votes
+ */
+function print_detailed_report() {
+  console.log('\n' + '='.repeat(80));
+  console.log('DETAILED ORPHANED VOTES REPORT');
+  console.log('='.repeat(80));
+
+  let total_affected_dacs = 0;
+  let total_orphaned_votes = 0;
+  let total_orphaned_references = 0;
+
+  for (const [dac_id, orphaned] of Object.entries(orphaned_votes)) {
+    if (orphaned.length > 0) {
+      total_affected_dacs++;
+      total_orphaned_votes += orphaned.length;
+      
+      console.log(`\n📋 DAC: ${dac_id}`);
+      console.log(`   Orphaned votes: ${orphaned.length}`);
+      
+      // Group by orphaned candidate to see patterns
+      const orphaned_candidates_summary = {};
+      for (const vote of orphaned) {
+        total_orphaned_references += vote.orphaned_candidates.length;
+        for (const orphaned_cand of vote.orphaned_candidates) {
+          if (!orphaned_candidates_summary[orphaned_cand]) {
+            orphaned_candidates_summary[orphaned_cand] = [];
+          }
+          orphaned_candidates_summary[orphaned_cand].push(vote.voter);
+        }
+      }
+      
+      console.log(`   Orphaned candidates and their voters:`);
+      for (const [candidate, voters] of Object.entries(orphaned_candidates_summary)) {
+        console.log(`     • ${candidate}: ${voters.length} votes from [${voters.join(', ')}]`);
+      }
+
+      // Show some example vote records
+      console.log(`   Example orphaned vote records:`);
+      for (let i = 0; i < Math.min(3, orphaned.length); i++) {
+        const vote = orphaned[i];
+        const vote_date = dayjs.utc(vote.vote_time_stamp).format('YYYY-MM-DD HH:mm:ss UTC');
+        console.log(`     ${i + 1}. Voter: ${vote.voter}`);
+        console.log(`        Date: ${vote_date}`);
+        console.log(`        Total candidates: ${vote.total_candidates}`);
+        console.log(`        Valid candidates: [${vote.valid_candidates.join(', ')}]`);
+        console.log(`        Orphaned candidates: [${vote.orphaned_candidates.join(', ')}]`);
+      }
+      
+      if (orphaned.length > 3) {
+        console.log(`     ... and ${orphaned.length - 3} more orphaned votes`);
+      }
+    }
+  }
+
+  console.log('\n' + '='.repeat(80));
+  console.log('SUMMARY');
+  console.log('='.repeat(80));
+  console.log(`Total DACs affected: ${total_affected_dacs}`);
+  console.log(`Total orphaned votes: ${total_orphaned_votes}`);
+  console.log(`Total orphaned candidate references: ${total_orphaned_references}`);
+  
+  if (total_affected_dacs === 0) {
+    console.log('🎉 No orphaned votes found across all DACs!');
+  } else {
+    console.log('\n⚠️  These orphaned votes indicate data inconsistency that may need to be addressed.');
+    console.log('   Consider running the vote weight rebuild procedure or cleaning up the votes.');
+  }
+}
+
+/**
+ * Save results to JSON file for further analysis
+ */
+function save_results() {
+  const fs = require('fs');
+  const timestamp = dayjs().format('YYYY-MM-DD_HH-mm-ss');
+  const filename = `orphaned_votes_report_${timestamp}.json`;
+  
+  const report = {
+    timestamp: dayjs().toISOString(),
+    endpoint: ENDPOINT,
+    contract: DAO_CONTRACT,
+    summary: {
+      total_dacs_checked: Object.keys(dac_data).length,
+      dacs_with_orphaned_votes: Object.keys(orphaned_votes).filter(dac_id => orphaned_votes[dac_id].length > 0).length,
+      total_orphaned_votes: Object.values(orphaned_votes).reduce((sum, votes) => sum + votes.length, 0),
+    },
+    detailed_results: orphaned_votes,
+    raw_data: dac_data
+  };
+  
+  fs.writeFileSync(filename, JSON.stringify(report, null, 2));
+  console.log(`\n💾 Detailed results saved to: ${filename}`);
+}
+
+/**
+ * Main execution function
+ */
+async function main() {
+  console.log('🔍 Checking for orphaned votes in daccustodian contract...');
+  console.log(`Endpoint: ${ENDPOINT}`);
+  console.log(`Contract: ${DAO_CONTRACT}`);
+  
+  try {
+    // Fetch all DAC IDs
+    const dac_ids = await fetch_dac_ids();
+    console.log(`Found ${dac_ids.length} DACs to check: [${dac_ids.join(', ')}]`);
+    
+    // Fetch data for each DAC
+    for (const dac_id of dac_ids) {
+      dac_data[dac_id] = await fetch_dac_tables(dac_id);
+      
+      // Add a small delay to avoid overwhelming the API
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    
+    // Check each DAC for orphaned votes
+    for (const dac_id of dac_ids) {
+      check_orphaned_votes(dac_id);
+    }
+    
+    // Print detailed report
+    print_detailed_report();
+    
+    // Save results
+    save_results();
+    
+  } catch (error) {
+    console.error('Error in main execution:', error);
+    process.exit(1);
+  }
+}
+
+// Run the script
+if (require.main === module) {
+  main().catch(error => {
+    console.error('Unhandled error:', error);
+    process.exit(1);
+  });
+}
+
+module.exports = { main, check_orphaned_votes, fetch_dac_tables };

--- a/debugging/rebuild_vote_weights/1_start_vote_weight_rebuild.sh
+++ b/debugging/rebuild_vote_weights/1_start_vote_weight_rebuild.sh
@@ -13,6 +13,7 @@
 #   SRC_DIR            Contract source dir (default contracts/daccustodian)
 #   BUILD_DIR          Build artefacts dir   (default $SRC_DIR/build)
 #   BATCH_SIZE         Unused here but passed through for downstream scripts.
+#   API_URL            Node endpoint passed to cleos -u (optional)
 #
 set -euo pipefail
 
@@ -26,6 +27,12 @@ function require_cmd() {
 require_cmd cleos
 
 CONTRACT_ACCOUNT="${CONTRACT_ACCOUNT:-dao.worlds}"
+# Optional API endpoint for cleos
+API_URL="${API_URL:-}"
+API_OPT=""
+if [[ -n "$API_URL" ]]; then
+  API_OPT="-u $API_URL"
+fi
 echo "Contract account: $CONTRACT_ACCOUNT"
 BUILD_DIR="artifacts/compiled_contracts/DEBUG/daccustodian"
 
@@ -35,10 +42,10 @@ lamington build -DDEBUG -p daccustodian -f
 
 echo "[2/3] Deploying DEBUG build to ${CONTRACT_ACCOUNT}…"
 
-cleos set contract "$CONTRACT_ACCOUNT" "$BUILD_DIR" -p "${CONTRACT_ACCOUNT}@active"
+cleos $API_OPT set contract "$CONTRACT_ACCOUNT" "$BUILD_DIR" -p "${CONTRACT_ACCOUNT}@active"
 
 echo "[3/3] Entering maintenance mode…"
 
-cleos push action "$CONTRACT_ACCOUNT" maintenance '[1]' -p "${CONTRACT_ACCOUNT}@active"
+cleos $API_OPT push action "$CONTRACT_ACCOUNT" maintenance '[1]' -p "${CONTRACT_ACCOUNT}@active"
 
 echo "✅ Maintenance window opened with DEBUG build deployed. Now run 2_rebuild_vote_weights_for_dac.sh" 

--- a/debugging/rebuild_vote_weights/1_start_vote_weight_rebuild.sh
+++ b/debugging/rebuild_vote_weights/1_start_vote_weight_rebuild.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Start vote-weight rebuild maintenance window.
+#
+# This script compiles the DEBUG build of the daccustodian contract (with
+# helper actions) and deploys it, then sets the contract into maintenance mode.
+# Execute once before processing multiple DACs.
+#
+# Usage:
+#   ./debugging/rebuild_vote_weights/1_start_vote_weight_rebuild.sh [batch_size]
+#
+# Environment variables (override as needed):
+#   CONTRACT_ACCOUNT   Contract account (default dao.worlds)
+#   SRC_DIR            Contract source dir (default contracts/daccustodian)
+#   BUILD_DIR          Build artefacts dir   (default $SRC_DIR/build)
+#   BATCH_SIZE         Unused here but passed through for downstream scripts.
+#
+set -euo pipefail
+
+function abort() {
+  echo "Error: $1" >&2
+  exit 1
+}
+function require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || abort "'$1' command not found";
+}
+require_cmd cleos
+
+CONTRACT_ACCOUNT="${CONTRACT_ACCOUNT:-dao.worlds}"
+echo "Contract account: $CONTRACT_ACCOUNT"
+BUILD_DIR="artifacts/compiled_contracts/DEBUG/daccustodian"
+
+
+echo "[1/3] Compiling DEBUG migration build…"
+lamington build -DDEBUG -p daccustodian -f
+
+echo "[2/3] Deploying DEBUG build to ${CONTRACT_ACCOUNT}…"
+
+cleos set contract "$CONTRACT_ACCOUNT" "$BUILD_DIR" -p "${CONTRACT_ACCOUNT}@active"
+
+echo "[3/3] Entering maintenance mode…"
+
+cleos push action "$CONTRACT_ACCOUNT" maintenance '[1]' -p "${CONTRACT_ACCOUNT}@active"
+
+echo "✅ Maintenance window opened with DEBUG build deployed. Now run 2_rebuild_vote_weights_for_dac.sh" 

--- a/debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh
+++ b/debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Rebuild vote weights for one or all DACs.
+# Assumes DEBUG build with helper actions is already deployed and contract
+# is in maintenance mode (started via start_vote_weight_rebuild.sh).
+#
+# Usage:
+#   ./debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh [dac_id1 dac_id2 ...]
+# If no dac_id arguments are supplied the script automatically fetches the list of DAC ids from
+# the dacdirectory contract (default index.worlds) and iterates over all of them.
+#
+# Example invocations:
+#   # 1. Run via a custom API endpoint (e.g., WAX mainnet)
+#   API_URL=https://wax.greymass.com ./debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh
+#
+#   # 2. Rebuild every DAC listed in the directory (default node URL, localhost)
+#   ./debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh
+#
+#   # 3. Rebuild a single DAC
+#   ./debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh alien.world
+#
+#   # 4. Rebuild two specific DACs with smaller batching
+#   ./debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh alien.world eggs.world --batch 50
+#
+#   # 5. Override custodian contract account
+#   CONTRACT_ACCOUNT=dao.syndicate ./debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh
+#
+# Options / Environment variables:
+#   --dacdir <account>    Directory contract account (default index.worlds)
+#   --batch <N>           Voters per batch (default 200 / $BATCH_SIZE env)
+#   CONTRACT_ACCOUNT      Custodian contract account (default dao.worlds)
+#   API_URL               Node endpoint passed to cleos -u (optional)
+#
+set -euo pipefail
+
+abort() { echo "Error: $1" >&2; exit 1; }
+require_cmd() { command -v "$1" >/dev/null 2>&1 || abort "'$1' command not found"; }
+require_cmd cleos
+require_cmd jq
+
+# Defaults
+CONTRACT_ACCOUNT="${CONTRACT_ACCOUNT:-dao.worlds}"
+DACDIR_ACC="index.worlds"
+BATCH_SIZE="${BATCH_SIZE:-200}"
+API_URL="${API_URL:-}"
+
+# Option parsing
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dacdir)
+      DACDIR_ACC="$2"; shift; shift;;
+    --batch)
+      BATCH_SIZE="$2"; shift; shift;;
+    *)
+      POSITIONAL+=("$1"); shift;;
+  esac
+done
+
+DAC_IDS=()
+if [[ ${#POSITIONAL[@]} -gt 0 ]]; then
+  DAC_IDS=("${POSITIONAL[@]}")
+else
+  echo "Fetching DAC IDs from directory $DACDIR_ACC …" >&2
+  if [[ -n "$API_URL" ]]; then
+    DAC_IDS=($(cleos -u "$API_URL" get table "$DACDIR_ACC" "$DACDIR_ACC" dacs --limit 1000 | jq -r '.rows[].dac_id'))
+  else
+    DAC_IDS=($(cleos get table "$DACDIR_ACC" "$DACDIR_ACC" dacs --limit 1000 | jq -r '.rows[].dac_id'))
+  fi
+fi
+
+[[ ${#DAC_IDS[@]} -eq 0 ]] && abort "No DAC ids to process."
+
+echo "Processing DACs: ${DAC_IDS[*]}"
+
+############################################################
+# Helper function to rebuild one DAC                        #
+############################################################
+rebuild_one() {
+  local DAC_ID="$1"
+
+  echo "\n================ Rebuilding weights for DAC '$DAC_ID' (batch $BATCH_SIZE) ================"
+
+  local API_OPT=""
+  if [[ -n "$API_URL" ]]; then
+    API_OPT="-u $API_URL"
+  fi
+
+
+  echo "DAC globals before: "
+  cleos $API_OPT get table "$CONTRACT_ACCOUNT" "$DAC_ID" dacglobals --limit 1
+
+  echo "🔄 Rebuilding vote weights for DAC '$DAC_ID' …"
+
+  # 0. Clear proxy-related data first
+  echo "🧹 Clearing proxy votes …"
+  cleos $API_OPT push action "$CONTRACT_ACCOUNT" clrprxvotes "[\"$DAC_ID\"]" -p "${CONTRACT_ACCOUNT}@active"
+
+  echo "🧹 Clearing proxies …"
+  cleos $API_OPT push action "$CONTRACT_ACCOUNT" clrproxies "[\"$DAC_ID\"]" -p "${CONTRACT_ACCOUNT}@active"
+
+  # Verify clearing
+  echo "Proxies table (should be empty):"
+  cleos $API_OPT get table "$CONTRACT_ACCOUNT" "$DAC_ID" proxies --limit 1000
+
+  echo "Votes delegating to proxy (should output nothing):"
+  cleos $API_OPT get table "$CONTRACT_ACCOUNT" "$DAC_ID" votes --limit 5000 | jq '.rows[] | select(.proxy != null and .proxy != "")'
+
+  # 1. Reset derived state
+  cleos $API_OPT push action "$CONTRACT_ACCOUNT" resetstate "[\"$DAC_ID\"]" -p "${CONTRACT_ACCOUNT}@active"
+  cleos $API_OPT push action "$CONTRACT_ACCOUNT" resetcands "[\"$DAC_ID\"]" -p "${CONTRACT_ACCOUNT}@active"
+
+  # 2. Fetch voters and replay
+  local VOTERS
+  VOTERS=$(cleos $API_OPT get table "$CONTRACT_ACCOUNT" "$DAC_ID" votes --limit 5000 | jq -r '.rows[].voter' | sort)
+
+  if [[ -z "$VOTERS" ]]; then
+    echo "No voters found for '$DAC_ID'. Skipping." && return
+  fi
+
+  IFS=$'\n' read -r -d '' -a VOTER_ARRAY < <(printf '%s\n' $VOTERS && printf '\0')
+
+  local TOTAL=${#VOTER_ARRAY[@]}
+  local INDEX=0
+  local BATCH_NUM=1
+  while [[ $INDEX -lt $TOTAL ]]; do
+    local END=$(( INDEX + BATCH_SIZE - 1 ))
+    (( END >= TOTAL )) && END=$(( TOTAL - 1 ))
+    local FIRST="${VOTER_ARRAY[$INDEX]}"
+    local TO_PARAM=""
+    if (( END + 1 < TOTAL )); then
+      TO_PARAM="${VOTER_ARRAY[$((END + 1))]}"
+    fi
+    echo "  Batch $BATCH_NUM: $FIRST → ${TO_PARAM:-<end>} (exclusive)"
+    cleos $API_OPT push action "$CONTRACT_ACCOUNT" collectvotes "[\"$DAC_ID\",\"$FIRST\",\"$TO_PARAM\"]" -p "${CONTRACT_ACCOUNT}@active"
+    INDEX=$(( END + 1 ))
+    BATCH_NUM=$(( BATCH_NUM + 1 ))
+  done
+
+  echo "DAC globals after: "
+  cleos $API_OPT get table "$CONTRACT_ACCOUNT" "$DAC_ID" dacglobals --limit 1
+
+  echo "✅ Completed vote-weight rebuild for '$DAC_ID'."
+}
+
+# Iterate over each DAC
+for DID in "${DAC_IDS[@]}"; do
+  rebuild_one "$DID"
+done
+
+echo "All done." 

--- a/debugging/rebuild_vote_weights/3_finish_vote_weight_rebuild.sh
+++ b/debugging/rebuild_vote_weights/3_finish_vote_weight_rebuild.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Finish vote-weight rebuild maintenance window.
+# Exits maintenance mode and deploys the normal (helper-free) build.
+#
+# Usage:
+#   ./finish_vote_weight_rebuild.sh
+#
+# Environment variables:
+#   CONTRACT_ACCOUNT   Contract account (default dao.worlds)
+#   SRC_DIR            Contract source dir (default contracts/daccustodian)
+#   BUILD_DIR          Build artefacts dir   (default $SRC_DIR/build)
+#
+set -euo pipefail
+
+abort() { echo "Error: $1" >&2; exit 1; }
+require_cmd() { command -v "$1" >/dev/null 2>&1 || abort "'$1' command not found"; }
+require_cmd cleos
+
+CONTRACT_ACCOUNT="${CONTRACT_ACCOUNT:-dao.worlds}"
+BUILD_DIR="artifacts/compiled_contracts/daccustodian"
+
+
+mkdir -p "$BUILD_DIR"
+
+echo "[1/3] Exiting maintenance mode…"
+cleos push action "$CONTRACT_ACCOUNT" maintenance '[0]' -p "${CONTRACT_ACCOUNT}@active"
+
+echo "[2/3] Compiling release build (helper-free)…"
+lamington build -p daccustodian -f
+
+echo "[3/3] Deploying release build…"
+cleos set contract "$CONTRACT_ACCOUNT" "$BUILD_DIR" -p "${CONTRACT_ACCOUNT}@active"
+
+echo "✅ Maintenance window closed and release build deployed." 

--- a/debugging/rebuild_vote_weights/3_finish_vote_weight_rebuild.sh
+++ b/debugging/rebuild_vote_weights/3_finish_vote_weight_rebuild.sh
@@ -9,6 +9,7 @@
 #   CONTRACT_ACCOUNT   Contract account (default dao.worlds)
 #   SRC_DIR            Contract source dir (default contracts/daccustodian)
 #   BUILD_DIR          Build artefacts dir   (default $SRC_DIR/build)
+#   API_URL            Node endpoint passed to cleos -u (optional)
 #
 set -euo pipefail
 
@@ -17,18 +18,23 @@ require_cmd() { command -v "$1" >/dev/null 2>&1 || abort "'$1' command not found
 require_cmd cleos
 
 CONTRACT_ACCOUNT="${CONTRACT_ACCOUNT:-dao.worlds}"
+API_URL="${API_URL:-}"
+API_OPT=""
+if [[ -n "$API_URL" ]]; then
+  API_OPT="-u $API_URL"
+fi
 BUILD_DIR="artifacts/compiled_contracts/daccustodian"
 
 
 mkdir -p "$BUILD_DIR"
 
 echo "[1/3] Exiting maintenance mode…"
-cleos push action "$CONTRACT_ACCOUNT" maintenance '[0]' -p "${CONTRACT_ACCOUNT}@active"
+cleos $API_OPT push action "$CONTRACT_ACCOUNT" maintenance '[0]' -p "${CONTRACT_ACCOUNT}@active"
 
 echo "[2/3] Compiling release build (helper-free)…"
 lamington build -p daccustodian -f
 
 echo "[3/3] Deploying release build…"
-cleos set contract "$CONTRACT_ACCOUNT" "$BUILD_DIR" -p "${CONTRACT_ACCOUNT}@active"
+cleos $API_OPT set contract "$CONTRACT_ACCOUNT" "$BUILD_DIR" -p "${CONTRACT_ACCOUNT}@active"
 
 echo "✅ Maintenance window closed and release build deployed." 

--- a/debugging/rebuild_vote_weights/vote_weight_rebuild_procedure.md
+++ b/debugging/rebuild_vote_weights/vote_weight_rebuild_procedure.md
@@ -1,0 +1,159 @@
+# In-Contract Vote-Weight Rebuild Procedure
+
+This document describes **Option 1 – “in-contract re-build”** for repairing incorrect `total_vote_power`, `running_weight_time`, `avg_vote_time_stamp`, and related global tallies in the `daccustodian` smart-contract tables that already exist on main-net.
+
+> The process is deterministic, on-chain, and requires no off-chain data. With fewer than **500 vote rows per DAC** it can be executed in just a couple of short batches.
+
+---
+
+## 0 Prerequisites
+
+- Contract source code that contains the bug-fixes **and** the DEBUG helpers:
+  - `maintenance(bool)`
+  - `resetstate(name dac_id)`
+  - `resetcands(name dac_id)`
+  - `collectvotes(name dac_id, name from, name to)`
+- Authority to deploy the contract (`dao.worlds@active`) and execute the helper actions.
+- CLI examples below use `tlm` as the DAC id – adjust as needed.
+
+---
+
+## 1 Preparation
+
+1. **Compile a temporary migration build**
+
+   ```bash
+   eosio-cpp -abigen -DIS_DEV -DDEBUG -o dao.worlds_mig.wasm src/daccustodian.cpp
+   ```
+
+   The `-DDEBUG` (or `-DIS_DEV`) flag ensures the helper actions are included.
+
+2. **Decide batch size** – 200 votes per `collectvotes` call is a safe default (≈ 40 ms CPU).
+
+---
+
+## 2 Start Maintenance Window
+
+```bash
+# Pause all user activity
+cleos push action dao.worlds maintenance '["1"]' -p dao.worlds@active
+
+# Deploy the migration build
+cleos set contract dao.worlds /path/to/build dao.worlds_mig.wasm daccustodian.abi -p dao.worlds@active
+```
+
+---
+
+## 3 Reset Derived State
+
+```bash
+# Zero global tallies
+cleos push action dao.worlds resetstate '["tlm"]' -p dao.worlds@active
+
+# Zero per-candidate fields & placeholder rank
+cleos push action dao.worlds resetcands '["tlm"]' -p dao.worlds@active
+```
+
+These two calls:
+
+- `total_weight_of_votes` and `total_votes_on_candidates` → 0
+- Every row in `candidates` table:
+  - `total_vote_power = 0`
+  - `number_voters = 0`
+  - `running_weight_time = 0`
+  - `avg_vote_time_stamp = 0`
+  - `rank` set to a dummy value (will be recomputed)
+
+---
+
+## 4 Replay Every Vote
+
+1. **Fetch current voters**
+
+   ```bash
+   cleos get table dao.worlds tlm votes --limit 1000 -k voter > votes.json
+   ```
+
+2. **Split into batches** (example in Bash):
+
+   ```bash
+   jq -r '.rows[].voter' votes.json | sort | xargs -n200 | while read first ... last; do
+       cleos push action dao.worlds collectvotes '["tlm","'${first}'","'${last}'"]' -p dao.worlds@active
+   done
+   ```
+
+`collectvotes` loops over the specified voter range and for each vote row:
+
+- Calls `update_number_of_votes` ➜ rebuilds `number_voters`.
+- Calls `modifyVoteWeights` ➜ which invokes `updateVoteWeight`, thereby recalculating `total_vote_power`, `running_weight_time`, `avg_vote_time_stamp`, and updates global tallies.
+
+With < 500 votes, three batches (a–m, n–t, u–z) are usually enough.
+
+---
+
+## 5 Verification
+
+- **Candidate check**
+
+  ```bash
+  cleos get table dao.worlds tlm candidates --lower alice --limit 1
+  ```
+
+- **Global totals**
+
+  ```bash
+  cleos get table dao.worlds tlm dacglobals --limit 1
+  ```
+
+  Ensure the following invariants hold:
+
+  - `total_weight_of_votes` equals the sum of weights for voters who currently have at least one vote.
+  - `total_votes_on_candidates` equals the sum of `total_vote_power` across all candidates.
+
+If a mismatch is detected, you can safely rerun **Reset** and **Replay** steps—they are idempotent.
+
+---
+
+## 6 Return to Production
+
+```bash
+# Deploy the normal (helper-free) build
+cleos set contract dao.worlds /path/to/release daccustodian.wasm daccustodian.abi -p dao.worlds@active
+
+# Re-enable user activity
+cleos push action dao.worlds maintenance '["0"]' -p dao.worlds@active
+```
+
+---
+
+## 7 Multiple DACs
+
+Repeat **Reset → Replay → Verify** for each DAC id (e.g. `testa`, `testb`). Because every DAC has < 500 votes the process is quick.
+
+### Example loop
+
+```bash
+dacs=(testa testb)
+for dac in "${dacs[@]}"; do
+  cleos push action  dao.worlds resetstate  "[\"${dac}\"]" -p  dao.worlds@active
+  cleos push action  dao.worlds resetcands  "[\"${dac}\"]" -p  dao.worlds@active
+  voters=$(cleos get table  dao.worlds ${dac} votes --limit 1000 -k voter | jq -r '.rows[].voter' | sort)
+  printf '%s\n' ${voters} | xargs -n200 | while read first ... last; do
+      cleos push action  dao.worlds collectvotes "[\"${dac}\",\"${first}\",\"${last}\"]" -p  dao.worlds@active
+  done
+  echo "Finished rebuilding for ${dac}"
+done
+```
+
+---
+
+## 8 Rollback / Safety
+
+• All helper actions are **idempotent** – you can repeat the whole sequence without side-effects.  
+• To cancel mid-migration simply redeploy the pre-migration contract and disable maintenance – the raw `votes` table was never altered.
+
+---
+
+## 9 Notes
+
+- The helper actions are protected by `require_auth(get_self())`. So it's safe to deploy the DEBUG build on main-net.


### PR DESCRIPTION
# This PR:

1) Adds debug helpers `clrprxvotes` and `clrproxies` to remove all proxy votes and registered proxies
2) 3 scripts to rebuild the vote weights
   - 1_start_vote_weight_rebuild.sh 
   - 2_rebuild_vote_weights.sh 
   - 3_finish_vote_weight_rebuild.sh

# Command description:
## 1_start_vote_weight_rebuild.sh 
1) builds the contract with DEBUG flag
2) deploys it
3) switches the contract into maintenance mode

## 2_rebuild_vote_weights.sh 
When no additional command line arguments are given, it automatically retrieves all dac ids from the `index.worlds` contract and loops over them. If only specific dacs should be processed, the dac id can be given as command line parameter. In this case, only the specified dac id will be processed.
1) Runs `clrprxvotes` to remove all proxy votes
2) Runs `clrproxies` to remove all proxies that have been unintentionally registered
3) Calls `resetstate` and `resetcands` to reset the vote weights and global state
4) Runs `collectvotes` in batches until all voters have been processed

## 3_finish_vote_weight_rebuild.sh
1) Exists maintenance mode
2) Builds the release build (without the DEBUG flag)
3) Deploys the contract

# Recommended procedure for the mainnet

Since the `dao.worlds` contract is managed by a multisig, we need to create a multisig to create a temporary active permission that will be used for this procedure. Make sure the required keys are in the local keyvault and that the keyvault is unlocked. 

Alternatively, we can 
1) Prepare 2 multisigs to deploy the DEBUG build and one to restore the PRODUCTION build once we're done.
2) Prepre a multisig to create a temporary custom permission that is linked only to the required debug actions `["clrprxvotes", "clrproxies", "resetstate", "resetcands", "collectvotes", "maintenance"]`.
3) Prepare a multisig to remove the temporary custom permission

When using the alternative process, the scripts 1 and 2 are not needed.

Then:

Set `API_URL` environment variable. 
```bash
export API_URL="https://wax.greymass.com" # or any other node on the wax mainnet
```
This will cause all following commands to use the specified API node for all cleos commands.

When a custom permission should be use (alternative approach), we can set it like this:
```bash
export PERMISSION="rebuild"
# This will cause the 2_rebuild_vote_weights.sh script to use this permission instead of the active permission.
```

Then we can run (when not using the alternative approach):
```bash
./debugging/rebuild_vote_weights/1_start_vote_weight_rebuild.sh
```
This will build the dacustodian contract with the DEBUG flag enabled, deploy it, and activate the maintenance mode.

Then we should test the rebuild with our test dacs:

```bash
./debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh testa testb
```

And verify that the vote weights and globals numbers look reasonable.

Once confident, we can run

```bash
./debugging/rebuild_vote_weights/2_rebuild_vote_weights.sh # without any parameters
```

This will loop over all existing dacs and rebuild the vote weight in batches. Additionally, it will erase the proxy votes and proxies.

Finally, we can run (when not using the alternative approach):

```bash
./debugging/rebuild_vote_weights/3_finish_vote_weight_rebuild.sh
```

This will compile the daccustodian contract without the DEBUG flag, deploy it and disable maintenance mode. When using the alternative approach, we must disable the maintenance mode manually here and then execute the multisig to restore the production build.

Finished. All vote weights and globals should now have the correct values.

Finally, we can remove the temporary permission in order to restore the original security posture.

